### PR TITLE
feat: provide function to customize pgwire handlers

### DIFF
--- a/datafusion-postgres/src/handlers.rs
+++ b/datafusion-postgres/src/handlers.rs
@@ -63,6 +63,7 @@ impl PgWireServerHandlers for HandlerFactory {
     }
 }
 
+/// The pgwire handler backed by a datafusion `SessionContext`
 pub struct DfSessionService {
     session_context: Arc<SessionContext>,
     parser: Arc<Parser>,


### PR DESCRIPTION
This patch adds initial entry point of custom pgwire handlers. For example, you can customize authentication handler from pgwire.