### PR TITLE
Per connection trasnaction tracking and cleanup

### DIFF
--- a/datafusion-postgres/src/handlers.rs
+++ b/datafusion-postgres/src/handlers.rs
@@ -141,15 +141,14 @@ impl DfSessionService {
         // Use a hash of PID, secret key, and socket address for better uniqueness
         let (pid, secret) = client.pid_and_secret_key();
         let socket_addr = client.socket_addr();
-        
+
         // Create a hash of all identifying values
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         pid.hash(&mut hasher);
         secret.hash(&mut hasher);
         socket_addr.hash(&mut hasher);
-        
-        let conn_id = hasher.finish();
-        conn_id
+
+        hasher.finish()
     }
 
     /// Check if the current user has permission to execute a query

--- a/datafusion-postgres/src/handlers.rs
+++ b/datafusion-postgres/src/handlers.rs
@@ -18,7 +18,9 @@ use pgwire::api::stmt::QueryParser;
 use pgwire::api::stmt::StoredStatement;
 use pgwire::api::{ClientInfo, PgWireServerHandlers, Type};
 use pgwire::error::{PgWireError, PgWireResult};
-use tokio::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use tokio::sync::{Mutex, RwLock};
 
 use arrow_pg::datatypes::df;
 use arrow_pg::datatypes::{arrow_schema_to_pg_fields, into_pg_type};
@@ -63,13 +65,26 @@ impl PgWireServerHandlers for HandlerFactory {
     }
 }
 
+/// Per-connection transaction state storage
+/// We use the process ID as the connection identifier since it's unique per connection
+pub type ConnectionId = i32;
+
+#[derive(Debug, Clone)]
+struct ConnectionState {
+    transaction_state: TransactionState,
+    last_activity: Instant,
+}
+
+type ConnectionStates = Arc<RwLock<HashMap<ConnectionId, ConnectionState>>>;
+
 /// The pgwire handler backed by a datafusion `SessionContext`
 pub struct DfSessionService {
     session_context: Arc<SessionContext>,
     parser: Arc<Parser>,
     timezone: Arc<Mutex<String>>,
-    transaction_state: Arc<Mutex<TransactionState>>,
+    connection_states: ConnectionStates,
     auth_manager: Arc<AuthManager>,
+    cleanup_counter: AtomicU64,
 }
 
 impl DfSessionService {
@@ -84,9 +99,46 @@ impl DfSessionService {
             session_context,
             parser,
             timezone: Arc::new(Mutex::new("UTC".to_string())),
-            transaction_state: Arc::new(Mutex::new(TransactionState::None)),
+            connection_states: Arc::new(RwLock::new(HashMap::new())),
             auth_manager,
+            cleanup_counter: AtomicU64::new(0),
         }
+    }
+
+    async fn get_transaction_state(&self, client_id: ConnectionId) -> TransactionState {
+        self.connection_states
+            .read()
+            .await
+            .get(&client_id)
+            .map(|s| s.transaction_state)
+            .unwrap_or(TransactionState::None)
+    }
+
+    async fn update_transaction_state(&self, client_id: ConnectionId, new_state: TransactionState) {
+        let mut states = self.connection_states.write().await;
+
+        // Update or insert state using entry API
+        states
+            .entry(client_id)
+            .and_modify(|s| {
+                s.transaction_state = new_state;
+                s.last_activity = Instant::now();
+            })
+            .or_insert(ConnectionState {
+                transaction_state: new_state,
+                last_activity: Instant::now(),
+            });
+
+        // Inline cleanup every 100 operations
+        if self.cleanup_counter.fetch_add(1, Ordering::Relaxed) % 100 == 0 {
+            let cutoff = Instant::now() - Duration::from_secs(3600);
+            states.retain(|_, state| state.last_activity > cutoff);
+        }
+    }
+
+    fn get_client_id<C: ClientInfo>(client: &C) -> ConnectionId {
+        // Use the process ID which is unique per connection
+        client.pid_and_secret_key().0
     }
 
     /// Check if the current user has permission to execute a query
@@ -213,18 +265,24 @@ impl DfSessionService {
         }
     }
 
-    async fn try_respond_transaction_statements<'a>(
+    async fn try_respond_transaction_statements<'a, C>(
         &self,
+        client: &C,
         query_lower: &str,
-    ) -> PgWireResult<Option<Response<'a>>> {
+    ) -> PgWireResult<Option<Response<'a>>>
+    where
+        C: ClientInfo,
+    {
+        let client_id = Self::get_client_id(client);
+
         // Transaction handling based on pgwire example:
         // https://github.com/sunng87/pgwire/blob/master/examples/transaction.rs#L57
         match query_lower.trim() {
             "begin" | "begin transaction" | "begin work" | "start transaction" => {
-                let mut state = self.transaction_state.lock().await;
-                match *state {
+                match self.get_transaction_state(client_id).await {
                     TransactionState::None => {
-                        *state = TransactionState::Active;
+                        self.update_transaction_state(client_id, TransactionState::Active)
+                            .await;
                         Ok(Some(Response::TransactionStart(Tag::new("BEGIN"))))
                     }
                     TransactionState::Active => {
@@ -245,10 +303,10 @@ impl DfSessionService {
                 }
             }
             "commit" | "commit transaction" | "commit work" | "end" | "end transaction" => {
-                let mut state = self.transaction_state.lock().await;
-                match *state {
+                match self.get_transaction_state(client_id).await {
                     TransactionState::Active => {
-                        *state = TransactionState::None;
+                        self.update_transaction_state(client_id, TransactionState::None)
+                            .await;
                         Ok(Some(Response::TransactionEnd(Tag::new("COMMIT"))))
                     }
                     TransactionState::None => {
@@ -257,14 +315,15 @@ impl DfSessionService {
                     }
                     TransactionState::Failed => {
                         // COMMIT in failed transaction is treated as ROLLBACK
-                        *state = TransactionState::None;
+                        self.update_transaction_state(client_id, TransactionState::None)
+                            .await;
                         Ok(Some(Response::TransactionEnd(Tag::new("ROLLBACK"))))
                     }
                 }
             }
             "rollback" | "rollback transaction" | "rollback work" | "abort" => {
-                let mut state = self.transaction_state.lock().await;
-                *state = TransactionState::None;
+                self.update_transaction_state(client_id, TransactionState::None)
+                    .await;
                 Ok(Some(Response::TransactionEnd(Tag::new("ROLLBACK"))))
             }
             _ => Ok(None),
@@ -343,7 +402,7 @@ impl SimpleQueryHandler for DfSessionService {
         }
 
         if let Some(resp) = self
-            .try_respond_transaction_statements(&query_lower)
+            .try_respond_transaction_statements(client, &query_lower)
             .await?
         {
             return Ok(vec![resp]);
@@ -354,17 +413,15 @@ impl SimpleQueryHandler for DfSessionService {
         }
 
         // Check if we're in a failed transaction and block non-transaction commands
-        {
-            let state = self.transaction_state.lock().await;
-            if *state == TransactionState::Failed {
-                return Err(PgWireError::UserError(Box::new(
-                    pgwire::error::ErrorInfo::new(
-                        "ERROR".to_string(),
-                        "25P01".to_string(),
-                        "current transaction is aborted, commands ignored until end of transaction block".to_string(),
-                    ),
-                )));
-            }
+        let client_id = Self::get_client_id(client);
+        if self.get_transaction_state(client_id).await == TransactionState::Failed {
+            return Err(PgWireError::UserError(Box::new(
+                pgwire::error::ErrorInfo::new(
+                    "ERROR".to_string(),
+                    "25P01".to_string(),
+                    "current transaction is aborted, commands ignored until end of transaction block".to_string(),
+                ),
+            )));
         }
 
         let df_result = self.session_context.sql(query).await;
@@ -374,11 +431,10 @@ impl SimpleQueryHandler for DfSessionService {
             Ok(df) => df,
             Err(e) => {
                 // If we're in a transaction and a query fails, mark transaction as failed
-                {
-                    let mut state = self.transaction_state.lock().await;
-                    if *state == TransactionState::Active {
-                        *state = TransactionState::Failed;
-                    }
+                let client_id = Self::get_client_id(client);
+                if self.get_transaction_state(client_id).await == TransactionState::Active {
+                    self.update_transaction_state(client_id, TransactionState::Failed)
+                        .await;
                 }
                 return Err(PgWireError::ApiError(Box::new(e)));
             }
@@ -496,8 +552,27 @@ impl ExtendedQueryHandler for DfSessionService {
             return Ok(resp);
         }
 
+        if let Some(resp) = self
+            .try_respond_transaction_statements(client, &query)
+            .await?
+        {
+            return Ok(resp);
+        }
+
         if let Some(resp) = self.try_respond_show_statements(&query).await? {
             return Ok(resp);
+        }
+
+        // Check if we're in a failed transaction and block non-transaction commands
+        let client_id = Self::get_client_id(client);
+        if self.get_transaction_state(client_id).await == TransactionState::Failed {
+            return Err(PgWireError::UserError(Box::new(
+                pgwire::error::ErrorInfo::new(
+                    "ERROR".to_string(),
+                    "25P01".to_string(),
+                    "current transaction is aborted, commands ignored until end of transaction block".to_string(),
+                ),
+            )));
         }
 
         let (_, plan) = &portal.statement.statement;
@@ -510,11 +585,18 @@ impl ExtendedQueryHandler for DfSessionService {
             .clone()
             .replace_params_with_values(&param_values)
             .map_err(|e| PgWireError::ApiError(Box::new(e)))?; // Fixed: Use &param_values
-        let dataframe = self
-            .session_context
-            .execute_logical_plan(plan)
-            .await
-            .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
+        let dataframe = match self.session_context.execute_logical_plan(plan).await {
+            Ok(df) => df,
+            Err(e) => {
+                // If we're in a transaction and a query fails, mark transaction as failed
+                let client_id = Self::get_client_id(client);
+                if self.get_transaction_state(client_id).await == TransactionState::Active {
+                    self.update_transaction_state(client_id, TransactionState::Failed)
+                        .await;
+                }
+                return Err(PgWireError::ApiError(Box::new(e)));
+            }
+        };
         let resp = df::encode_dataframe(dataframe, &portal.result_column_format).await?;
         Ok(Response::Query(resp))
     }
@@ -554,4 +636,135 @@ fn ordered_param_types(types: &HashMap<String, Option<DataType>>) -> Vec<Option<
     let mut types = types.iter().collect::<Vec<_>>();
     types.sort_by(|a, b| a.0.cmp(b.0));
     types.into_iter().map(|pt| pt.1.as_ref()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::SessionContext;
+
+    #[tokio::test]
+    async fn test_transaction_isolation() {
+        let session_context = Arc::new(SessionContext::new());
+        let auth_manager = Arc::new(AuthManager::new());
+        let service = DfSessionService::new(session_context, auth_manager);
+
+        // Simulate two different connection IDs
+        let client_id_1 = 1001;
+        let client_id_2 = 1002;
+
+        // Client 1 starts a transaction
+        service
+            .update_transaction_state(client_id_1, TransactionState::Active)
+            .await;
+
+        // Client 2 starts a transaction
+        service
+            .update_transaction_state(client_id_2, TransactionState::Active)
+            .await;
+
+        // Verify both have active transactions independently
+        {
+            let states = service.connection_states.read().await;
+            assert_eq!(
+                states.get(&client_id_1).map(|s| s.transaction_state),
+                Some(TransactionState::Active)
+            );
+            assert_eq!(
+                states.get(&client_id_2).map(|s| s.transaction_state),
+                Some(TransactionState::Active)
+            );
+        }
+
+        // Client 1 fails a transaction
+        service
+            .update_transaction_state(client_id_1, TransactionState::Failed)
+            .await;
+
+        // Verify client 1 is failed but client 2 is still active
+        {
+            let states = service.connection_states.read().await;
+            assert_eq!(
+                states.get(&client_id_1).map(|s| s.transaction_state),
+                Some(TransactionState::Failed)
+            );
+            assert_eq!(
+                states.get(&client_id_2).map(|s| s.transaction_state),
+                Some(TransactionState::Active)
+            );
+        }
+
+        // Client 1 rollback
+        service
+            .update_transaction_state(client_id_1, TransactionState::None)
+            .await;
+
+        // Client 2 commit
+        service
+            .update_transaction_state(client_id_2, TransactionState::None)
+            .await;
+
+        // Verify both are back to None state
+        {
+            let states = service.connection_states.read().await;
+            assert_eq!(
+                states.get(&client_id_1).map(|s| s.transaction_state),
+                Some(TransactionState::None)
+            );
+            assert_eq!(
+                states.get(&client_id_2).map(|s| s.transaction_state),
+                Some(TransactionState::None)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_opportunistic_cleanup() {
+        let session_context = Arc::new(SessionContext::new());
+        let auth_manager = Arc::new(AuthManager::new());
+        let service = DfSessionService::new(session_context, auth_manager);
+
+        // Add some connection states
+        service
+            .update_transaction_state(2001, TransactionState::Active)
+            .await;
+        service
+            .update_transaction_state(2002, TransactionState::Failed)
+            .await;
+
+        // Manually create an old connection
+        {
+            let mut states = service.connection_states.write().await;
+            states.insert(
+                2003,
+                ConnectionState {
+                    transaction_state: TransactionState::Active,
+                    last_activity: Instant::now() - Duration::from_secs(7200), // 2 hours old
+                },
+            );
+        }
+
+        // Set cleanup counter to trigger cleanup on next update (fetch_add returns old value)
+        service.cleanup_counter.store(99, Ordering::Relaxed);
+
+        // First update sets counter to 100 (99 + 1)
+        service
+            .update_transaction_state(2004, TransactionState::Active)
+            .await;
+
+        // This should trigger cleanup (counter becomes 100, 100 % 100 == 0)
+        service
+            .update_transaction_state(2005, TransactionState::Active)
+            .await;
+
+        // Verify only the old connection was removed (cleanup is now inline, no wait needed)
+        {
+            let states = service.connection_states.read().await;
+            assert!(states.contains_key(&2001));
+            assert!(states.contains_key(&2002));
+            assert!(!states.contains_key(&2003)); // Old connection should be removed
+            assert!(states.contains_key(&2004));
+            assert!(states.contains_key(&2005));
+        }
+    }
 }


### PR DESCRIPTION
 I ran into an issue where the entire global transaction state is marked as TransactionState::Failed, causing every other transaction to fail until the server is restarted, due to having a single transaction state for the entire application. 
 
 When failing, all queries even from new connections return an error 
 
 ```sql
 postgres=> select name,project_id,timestamp from otel_logs_and_spans where project_id='00000000-0000-0000-0000-000000000000' and date='2025-08-07' limit 30;
ERROR:  current transaction is aborted, commands ignored until end of transaction block
```
 
 
 This PR refactors transaction state management to be per-connection (like postgres) instead of global:

  - Per-connection isolation: Each connection now maintains its own transaction state using a HashMap<ConnectionId, ConnectionState> with the process ID as the unique identifier
  - Thread-safe access: Replaced Mutex with RwLock for better concurrent read performance
  - Automatic cleanup: Implemented opportunistic cleanup that removes stale connections (>1 hour inactive) every 100 state updates to prevent memory leaks