### PR TITLE
Enhanced Server Stability and Configuration Control

### DIFF
--- a/arrow-pg/src/datatypes.rs
+++ b/arrow-pg/src/datatypes.rs
@@ -42,8 +42,7 @@ pub fn into_pg_type(arrow_type: &DataType) -> PgWireResult<Type> {
         DataType::Float16 | DataType::Float32 => Type::FLOAT4,
         DataType::Float64 => Type::FLOAT8,
         DataType::Decimal128(_, _) => Type::NUMERIC,
-        DataType::Utf8 => Type::VARCHAR,
-        DataType::LargeUtf8 | DataType::Utf8View => Type::TEXT,
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Type::TEXT,
         DataType::List(field) | DataType::FixedSizeList(field, _) | DataType::LargeList(field) => {
             match field.data_type() {
                 DataType::Boolean => Type::BOOL_ARRAY,
@@ -67,8 +66,7 @@ pub fn into_pg_type(arrow_type: &DataType) -> PgWireResult<Type> {
                 | DataType::BinaryView => Type::BYTEA_ARRAY,
                 DataType::Float16 | DataType::Float32 => Type::FLOAT4_ARRAY,
                 DataType::Float64 => Type::FLOAT8_ARRAY,
-                DataType::Utf8 => Type::VARCHAR_ARRAY,
-                DataType::LargeUtf8 | DataType::Utf8View => Type::TEXT_ARRAY,
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Type::TEXT_ARRAY,
                 struct_type @ DataType::Struct(_) => Type::new(
                     Type::RECORD_ARRAY.name().into(),
                     Type::RECORD_ARRAY.oid(),

--- a/arrow-pg/src/datatypes/df.rs
+++ b/arrow-pg/src/datatypes/df.rs
@@ -66,11 +66,9 @@ where
         } else if let Some(infer_type) = inferenced_type {
             into_pg_type(infer_type)
         } else {
-            Err(PgWireError::UserError(Box::new(ErrorInfo::new(
-                "FATAL".to_string(),
-                "XX000".to_string(),
-                "Unknown parameter type".to_string(),
-            ))))
+            // Default to TEXT/VARCHAR for untyped parameters
+            // This allows arithmetic operations to work with implicit casting
+            Ok(Type::TEXT)
         }
     }
 

--- a/arrow-pg/src/encoder.rs
+++ b/arrow-pg/src/encoder.rs
@@ -574,7 +574,7 @@ mod tests {
             {
                 let mut bytes = BytesMut::new();
                 let _sql_text = value.to_sql_text(data_type, &mut bytes);
-                let string = String::from_utf8((&bytes).to_vec());
+                let string = String::from_utf8(bytes.to_vec());
                 self.encoded_value = string.unwrap();
                 Ok(())
             }

--- a/datafusion-postgres/src/lib.rs
+++ b/datafusion-postgres/src/lib.rs
@@ -100,7 +100,11 @@ pub async fn serve(
     let auth_manager = Arc::new(AuthManager::new());
 
     // Create the handler factory with authentication
-    let factory = Arc::new(HandlerFactory::new(session_context, auth_manager, opts.query_timeout));
+    let factory = Arc::new(HandlerFactory::new(
+        session_context,
+        auth_manager,
+        opts.query_timeout,
+    ));
 
     serve_with_handlers(factory, opts).await
 }

--- a/datafusion-postgres/src/sql.rs
+++ b/datafusion-postgres/src/sql.rs
@@ -296,7 +296,7 @@ struct RemoveUnsupportedTypesVisitor<'a> {
     unsupported_types: &'a HashSet<String>,
 }
 
-impl<'a> VisitorMut for RemoveUnsupportedTypesVisitor<'a> {
+impl VisitorMut for RemoveUnsupportedTypesVisitor<'_> {
     type Break = ();
 
     fn pre_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
@@ -444,7 +444,7 @@ struct PrependUnqualifiedTableNameVisitor<'a> {
     table_names: &'a HashSet<String>,
 }
 
-impl<'a> VisitorMut for PrependUnqualifiedTableNameVisitor<'a> {
+impl VisitorMut for PrependUnqualifiedTableNameVisitor<'_> {
     type Break = ();
 
     fn pre_visit_table_factor(

--- a/datafusion-postgres/tests/common/mod.rs
+++ b/datafusion-postgres/tests/common/mod.rs
@@ -14,7 +14,11 @@ pub fn setup_handlers() -> DfSessionService {
     let session_context = SessionContext::new();
     setup_pg_catalog(&session_context, "datafusion").expect("Failed to setup sesession context");
 
-    DfSessionService::new(Arc::new(session_context), Arc::new(AuthManager::new()), Some(std::time::Duration::from_secs(30)))
+    DfSessionService::new(
+        Arc::new(session_context),
+        Arc::new(AuthManager::new()),
+        Some(std::time::Duration::from_secs(30)),
+    )
 }
 
 #[derive(Debug, Default)]

--- a/datafusion-postgres/tests/common/mod.rs
+++ b/datafusion-postgres/tests/common/mod.rs
@@ -14,7 +14,7 @@ pub fn setup_handlers() -> DfSessionService {
     let session_context = SessionContext::new();
     setup_pg_catalog(&session_context, "datafusion").expect("Failed to setup sesession context");
 
-    DfSessionService::new(Arc::new(session_context), Arc::new(AuthManager::new()))
+    DfSessionService::new(Arc::new(session_context), Arc::new(AuthManager::new()), Some(std::time::Duration::from_secs(30)))
 }
 
 #[derive(Debug, Default)]

--- a/datafusion-postgres/tests/dbeaver.rs
+++ b/datafusion-postgres/tests/dbeaver.rs
@@ -34,6 +34,6 @@ pub async fn test_dbeaver_startup_sql() {
     for query in DBEAVER_QUERIES {
         SimpleQueryHandler::do_query(&service, &mut client, query)
             .await
-            .expect(&format!("failed to run sql: {query}"));
+            .unwrap_or_else(|_| panic!("failed to run sql: {query}"));
     }
 }


### PR DESCRIPTION
Fixed Parameter Type Issues: Resolved crashes from untyped parameters (e.g., $1 + $2) by setting them to default to TEXT, allowing DataFusion to handle type coercion.

Resolved Schema Consistency Problems: Unified VARCHAR and TEXT types to TEXT, ensuring compatibility with most Postgres tools and eliminating schema mismatches.

Improved Connection Stability: Implemented connection limiting to prevent server crashes from excessive concurrent connections, avoiding resource exhaustion.

Added Configurable Query Timeout: Introduced query timeout settings via ServerOptions::new().with_query_timeout_secs(30) for a 30-second timeout, or 0 for no timeout, to prevent runaway queries.

Enhanced Connection Control: Added .with_max_connections(500) to allow limiting connections, enabling the server to reject excess connections gracefully.