### PR TITLE
Fix parameter type inference for untyped parameters in extended queries

### DIFF
--- a/arrow-pg/src/datatypes.rs
+++ b/arrow-pg/src/datatypes.rs
@@ -42,8 +42,7 @@ pub fn into_pg_type(arrow_type: &DataType) -> PgWireResult<Type> {
         DataType::Float16 | DataType::Float32 => Type::FLOAT4,
         DataType::Float64 => Type::FLOAT8,
         DataType::Decimal128(_, _) => Type::NUMERIC,
-        DataType::Utf8 => Type::VARCHAR,
-        DataType::LargeUtf8 | DataType::Utf8View => Type::TEXT,
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Type::TEXT,
         DataType::List(field) | DataType::FixedSizeList(field, _) | DataType::LargeList(field) => {
             match field.data_type() {
                 DataType::Boolean => Type::BOOL_ARRAY,
@@ -67,8 +66,7 @@ pub fn into_pg_type(arrow_type: &DataType) -> PgWireResult<Type> {
                 | DataType::BinaryView => Type::BYTEA_ARRAY,
                 DataType::Float16 | DataType::Float32 => Type::FLOAT4_ARRAY,
                 DataType::Float64 => Type::FLOAT8_ARRAY,
-                DataType::Utf8 => Type::VARCHAR_ARRAY,
-                DataType::LargeUtf8 | DataType::Utf8View => Type::TEXT_ARRAY,
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Type::TEXT_ARRAY,
                 struct_type @ DataType::Struct(_) => Type::new(
                     Type::RECORD_ARRAY.name().into(),
                     Type::RECORD_ARRAY.oid(),

--- a/arrow-pg/src/datatypes/df.rs
+++ b/arrow-pg/src/datatypes/df.rs
@@ -66,11 +66,9 @@ where
         } else if let Some(infer_type) = inferenced_type {
             into_pg_type(infer_type)
         } else {
-            Err(PgWireError::UserError(Box::new(ErrorInfo::new(
-                "FATAL".to_string(),
-                "XX000".to_string(),
-                "Unknown parameter type".to_string(),
-            ))))
+            // Default to TEXT for untyped parameters in extended queries
+            // This allows arithmetic operations to work with implicit casting
+            Ok(Type::TEXT)
         }
     }
 


### PR DESCRIPTION
- Default to TEXT type instead of throwing fatal errors for unknown parameter types
- Allows arithmetic operations with untyped parameters to work through implicit casting
- Unify all UTF8 Arrow variants (Utf8, LargeUtf8, Utf8View) to use TEXT type consistently
- Resolves schema mismatches between TEXT/VARCHAR type expectations

This fixes issues where queries like 'SELECT  + ' would fail with 'Unknown parameter type' errors when DataFusion couldn't infer the parameter types from context.