### PR TITLE
Fix #227: handle multiple statements with hooks

### DIFF
--- a/datafusion-postgres/src/handlers.rs
+++ b/datafusion-postgres/src/handlers.rs
@@ -767,24 +767,25 @@ mod tests {
     async fn test_multiple_statements_with_hook_continue() {
         // Bug #227: when a hook returned a result, the code used `break 'stmt`
         // which would exit the entire statement loop, preventing subsequent statements
-        // from being processed.        
+        // from being processed.
         let session_context = Arc::new(SessionContext::new());
         let auth_manager = Arc::new(AuthManager::new());
-        
+
         let hooks: Vec<Arc<dyn QueryHook>> = vec![Arc::new(TestHook)];
         let service = DfSessionService::new_with_hooks(session_context, auth_manager, hooks);
-        
+
         let mut client = MockClient::new();
-        
+
         // Mix of queries with hooks and those without
         let query = "SELECT magic; SELECT 1; SELECT magic; SELECT 1";
-        
-        let results = <DfSessionService as SimpleQueryHandler>::do_query(&service, &mut client, query)
-            .await
-            .unwrap();
-        
+
+        let results =
+            <DfSessionService as SimpleQueryHandler>::do_query(&service, &mut client, query)
+                .await
+                .unwrap();
+
         assert_eq!(results.len(), 4, "Expected 4 responses");
-        
+
         assert!(matches!(results[0], Response::EmptyQuery));
         assert!(matches!(results[1], Response::Query(_)));
         assert!(matches!(results[2], Response::EmptyQuery));


### PR DESCRIPTION
This PR addresses an issue when multiple statements appear in a simple query and at least one of which is handled by a hook.

Basically I had hooks for RESET, CLOSE, DISCARD, and UNLISTEN (contribution requires an upstream change to datafusion-sqlparser-rs which has been proposed), and npgsql issued them all in the same query. Only one of these would be handled causing npgsql to timeout.

Fixes #227