### PR TITLE
fix: use text format as default in describe statement

### DIFF
--- a/datafusion-postgres/src/handlers.rs
+++ b/datafusion-postgres/src/handlers.rs
@@ -408,7 +408,7 @@ impl QueryParser for Parser {
             let schema = plan.schema();
             let fields = arrow_schema_to_pg_fields(
                 schema.as_arrow(),
-                column_format.unwrap_or(&Format::UnifiedBinary),
+                column_format.unwrap_or(&Format::UnifiedText),
                 None,
             )?;
 


### PR DESCRIPTION
When describing statement, there is no format information available. We will use text format as default to align with postgres