### PR TITLE
fix: only return schema for query

### DIFF
--- a/datafusion-postgres/src/handlers.rs
+++ b/datafusion-postgres/src/handlers.rs
@@ -405,14 +405,18 @@ impl QueryParser for Parser {
         column_format: Option<&Format>,
     ) -> PgWireResult<Vec<FieldInfo>> {
         if let (_, Some((_, plan))) = stmt {
-            let schema = plan.schema();
-            let fields = arrow_schema_to_pg_fields(
-                schema.as_arrow(),
-                column_format.unwrap_or(&Format::UnifiedText),
-                None,
-            )?;
+            if !matches!(plan, LogicalPlan::Ddl(_) | LogicalPlan::Dml(_)) {
+                let schema = plan.schema();
+                let fields = arrow_schema_to_pg_fields(
+                    schema.as_arrow(),
+                    column_format.unwrap_or(&Format::UnifiedText),
+                    None,
+                )?;
 
-            Ok(fields)
+                Ok(fields)
+            } else {
+                Ok(vec![])
+            }
         } else {
             Ok(vec![])
         }


### PR DESCRIPTION
Datafusion is capable with returning schema for DML statements, however, postgres clients expect empty schema for them. This patch fix the behaviour.

Reference:

> org.postgresql.util.PSQLException: A result was returned when none was expected.

https://github.com/GreptimeTeam/greptimedb/actions/runs/24402788204/job/71281078806#step:16:8042