### PR TITLE
fix: ordered_param_types and add unit test

### DIFF
--- a/datafusion-postgres/src/handlers.rs
+++ b/datafusion-postgres/src/handlers.rs
@@ -474,7 +474,11 @@ fn ordered_param_types(types: &HashMap<String, Option<DataType>>) -> Vec<Option<
     // Datafusion stores the parameters as a map.  In our case, the keys will be
     // `$1`, `$2` etc.  The values will be the parameter types.
     let mut types = types.iter().collect::<Vec<_>>();
-    types.sort_by(|a, b| a.0.cmp(b.0));
+    types.sort_by_key(|(key, _)| {
+        key.trim_start_matches('$')
+            .parse::<u32>()
+            .unwrap_or(u32::MAX)
+    });
     types.into_iter().map(|pt| pt.1.as_ref()).collect()
 }
 
@@ -525,6 +529,29 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_ordered_param_types_sorts_placeholders_numerically() {
+        let params = HashMap::from([
+            ("$1".to_string(), Some(DataType::Boolean)),
+            ("$2".to_string(), Some(DataType::Int64)),
+            ("$10".to_string(), Some(DataType::Utf8)),
+        ]);
+
+        let ordered = ordered_param_types(&params)
+            .into_iter()
+            .map(|ty| ty.cloned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            ordered,
+            vec![
+                Some(DataType::Boolean),
+                Some(DataType::Int64),
+                Some(DataType::Utf8)
+            ]
+        );
+    }
+    
     #[tokio::test]
     async fn test_query_hooks() {
         let hook = TestHook;

--- a/datafusion-postgres/src/handlers.rs
+++ b/datafusion-postgres/src/handlers.rs
@@ -551,7 +551,7 @@ mod tests {
             ]
         );
     }
-    
+
     #[tokio::test]
     async fn test_query_hooks() {
         let hook = TestHook;


### PR DESCRIPTION
`ordered_param_types()` received inferred parameter types from DataFusion as a `HashMap` keyed by strings such as `$1`, `$2`, ..., `$10`. Because `HashMap`s are unordered, the code sorted the keys before building the positional parameter type list returned to the client.

However, the keys were sorted lexicographically:

```text
$1, $10, $2, $3, ...
```

instead of numerically:

```text
$1, $2, $3, ..., $10
```

For queries with more than nine placeholders, this caused parameter types to be assigned to the wrong positions. For example, the type inferred for `$10` could be reported or used as if it belonged to `$2`. As a result, clients could bind or deserialize values using incorrect PostgreSQL types, such as treating a UUID parameter as a timestamp.

The fix was to sort parameters by their numeric suffix:

```rust
types.sort_by_key(|(key, _)| {
    key.trim_start_matches('$')
        .parse::<u32>()
        .unwrap_or(u32::MAX)
});
```