### PR TITLE
fix(pg-catalog): restrict unqualified pg table rewrite

### DIFF
--- a/datafusion-pg-catalog/src/sql/rules.rs
+++ b/datafusion-pg-catalog/src/sql/rules.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::ops::ControlFlow;
 
-use crate::pg_catalog::oid_field;
+use crate::pg_catalog::{PG_CATALOG_TABLES, oid_field};
 
 use datafusion::sql::sqlparser::ast::Array;
 use datafusion::sql::sqlparser::ast::ArrayElemTypeDef;
@@ -512,9 +512,18 @@ impl SqlStatementRewriteRule for RewriteArrayAnyAllOperation {
 /// Prepend qualifier to table_name
 ///
 /// Postgres has pg_catalog in search_path by default so it allow access to
-/// `pg_namespace` without `pg_catalog.` qualifier
+/// `pg_namespace` without `pg_catalog.` qualifier.
+///
+/// Only names of known pg_catalog relations are qualified. A simple `pg_`
+/// prefix check would also rewrite user tables such as `pg_compat_test`.
 #[derive(Debug)]
 pub struct PrependUnqualifiedPgTableName;
+
+fn is_pg_catalog_table(name: &str) -> bool {
+    PG_CATALOG_TABLES
+        .iter()
+        .any(|table| table.eq_ignore_ascii_case(name))
+}
 
 struct PrependUnqualifiedPgTableNameVisitor;
 
@@ -530,7 +539,7 @@ impl VisitorMut for PrependUnqualifiedPgTableNameVisitor {
             if args.is_none()
                 && name.0.len() == 1
                 && let ObjectNamePart::Identifier(ident) = &name.0[0]
-                && ident.value.starts_with("pg_")
+                && is_pg_catalog_table(&ident.value)
             {
                 *name = ObjectName(vec![
                     ObjectNamePart::Identifier(Ident::new("pg_catalog")),
@@ -1171,8 +1180,26 @@ mod tests {
 
         assert_rewrite!(
             &rules,
+            "SELECT * FROM pg_type",
+            "SELECT * FROM pg_catalog.pg_type"
+        );
+
+        assert_rewrite!(
+            &rules,
             "SELECT typtype, typname, pg_type.oid FROM pg_catalog.pg_type LEFT JOIN pg_namespace as ns ON ns.oid = oid",
             "SELECT typtype, typname, pg_type.oid FROM pg_catalog.pg_type LEFT JOIN pg_catalog.pg_namespace AS ns ON ns.oid = oid"
+        );
+
+        assert_rewrite!(
+            &rules,
+            "SELECT * FROM pg_compat_test",
+            "SELECT * FROM pg_compat_test"
+        );
+
+        assert_rewrite!(
+            &rules,
+            "SELECT * FROM pg_custom_table",
+            "SELECT * FROM pg_custom_table"
         );
     }
 


### PR DESCRIPTION
## Summary
- Restrict `PrependUnqualifiedPgTableName` to known `PG_CATALOG_TABLES` instead of every unqualified `pg_*` name.
- Preserve unqualified pg_catalog relation support such as `pg_namespace` and `pg_type`.
- Add regression coverage so user tables like `pg_compat_test` are not rewritten to `pg_catalog`.

This keeps the PostgreSQL implicit `pg_catalog` search path compatibility while avoiding false positives for user-defined tables whose names start with `pg_`.

Related: GreptimeTeam/greptimedb#8359

## Tests
- `cargo test --manifest-path datafusion-pg-catalog/Cargo.toml test_prepend_unqualified_table_name`
- `cargo test --manifest-path datafusion-pg-catalog/Cargo.toml --lib`
