### PR TITLE
fix: current_database() returns the configured catalog name, not the literal "datafusion"

### DIFF
--- a/datafusion-pg-catalog/src/pg_catalog.rs
+++ b/datafusion-pg-catalog/src/pg_catalog.rs
@@ -1080,12 +1080,16 @@ pub fn create_current_schema_udf() -> ScalarUDF {
     )
 }
 
-pub fn create_current_database_udf() -> ScalarUDF {
+pub fn create_current_database_udf(database_name: &str) -> ScalarUDF {
+    // `current_database()` is fixed for the life of a connection in
+    // PostgreSQL, so capture the catalog name the session was set up
+    // with and return it verbatim.
+    let database_name = database_name.to_string();
     // Define the function implementation
     let func = move |_args: &[ColumnarValue]| {
         // Create a UTF8 array with a single value
         let mut builder = StringBuilder::new();
-        builder.append_value("datafusion");
+        builder.append_value(&database_name);
         let array: ArrayRef = Arc::new(builder.finish());
 
         Ok(ColumnarValue::Array(array))
@@ -1459,7 +1463,7 @@ where
         })?
         .register_schema("pg_catalog", pg_catalog.clone())?;
 
-    session_context.register_udf(create_current_database_udf());
+    session_context.register_udf(create_current_database_udf(catalog_name));
     session_context.register_udf(create_current_schema_udf());
     session_context.register_udf(create_current_schemas_udf());
     //    session_context.register_udf(create_version_udf());
@@ -1527,6 +1531,36 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[tokio::test]
+    async fn current_database_returns_the_configured_catalog_name() {
+        use crate::pg_catalog::context::EmptyContextProvider;
+        use datafusion::arrow::array::StringArray;
+        use datafusion::prelude::{SessionConfig, SessionContext};
+
+        // Regression: `current_database()` used to return the hardcoded
+        // literal "datafusion" regardless of the catalog the session was
+        // set up with. It must reflect the configured catalog name.
+        let config = SessionConfig::new().with_default_catalog_and_schema("my_database", "public");
+        let ctx = SessionContext::new_with_config(config);
+        setup_pg_catalog(&ctx, "my_database", EmptyContextProvider).unwrap();
+
+        let batches = ctx
+            .sql("SELECT current_database()")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let value = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("current_database() returns a Utf8 column")
+            .value(0);
+        assert_eq!(value, "my_database");
+    }
 
     #[test]
     fn test_load_arrow_data() {


### PR DESCRIPTION
## Problem

`create_current_database_udf()` registers a `current_database()` UDF that returns the **hardcoded literal `"datafusion"`**, regardless of the catalog the session was actually set up with:

```rust
builder.append_value("datafusion"); // always
```

But `setup_pg_catalog(session_context, catalog_name, ...)` already knows the real catalog name — it registers `pg_catalog` under exactly that name a few lines above. So a client that connects to catalog `mydb` and runs `SELECT current_database()` gets `"datafusion"` instead of `"mydb"`.

In PostgreSQL, `current_database()` reflects the database the client connected to and is fixed for the life of the connection. Tools that key off it — psql's `\conninfo` / prompt substitution, some ORMs and schema-migration tools that route by `current_database()`, `pg_table_is_visible()`-style visibility helpers — misbehave against the hardcoded value.

## Fix

Thread the catalog name that `setup_pg_catalog` already has in scope into the UDF, and return it verbatim:

```rust
pub fn create_current_database_udf(database_name: &str) -> ScalarUDF {
    let database_name = database_name.to_string();
    let func = move |_args: &[ColumnarValue]| {
        let mut builder = StringBuilder::new();
        builder.append_value(&database_name);
        ...
    };
    ...
}
```

and at the call site:

```rust
session_context.register_udf(create_current_database_udf(catalog_name));
```

No new plumbing — `catalog_name` is already a parameter of `setup_pg_catalog`.

## Compatibility note

`create_current_database_udf` is `pub`, so adding the `&str` parameter is a **breaking signature change** for anyone calling it directly (the in-repo call site is the only caller in this workspace, and it's updated here). If you'd prefer to preserve the old zero-arg signature, I'm happy to instead add a second `create_current_database_udf_for(name: &str)` and keep the old one as a thin wrapper — just let me know which you'd rather carry.

## Test

Added a regression test in `datafusion-pg-catalog`'s `pg_catalog` test module: set up the catalog under `"my_database"`, run `SELECT current_database()`, and assert it returns `"my_database"` (not `"datafusion"`).

## Context

Found while building a multi-catalog pg-wire frontend on top of `datafusion-pg-catalog`, where each connection maps to a distinct catalog and `current_database()` needs to reflect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
