### PR TITLE
feat(pg-functions): implement PostgreSQL math functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,8 @@ name = "datafusion-pg-functions"
 version = "0.1.0"
 dependencies = [
  "datafusion",
+ "libm",
+ "rand 0.9.2",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,12 +89,27 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -107,6 +122,15 @@ name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "anstyle-parse"
@@ -789,6 +813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -797,8 +822,22 @@ version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
+ "anstream 0.6.21",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1437,7 +1476,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
  "num-traits",
  "rand 0.9.2",
@@ -1597,9 +1636,12 @@ dependencies = [
 name = "datafusion-pg-functions"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "datafusion",
+ "env_logger",
  "libm",
  "rand 0.9.2",
+ "sqllogictest",
  "tokio",
 ]
 
@@ -1860,10 +1902,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "env_filter"
@@ -1881,7 +1955,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "env_filter",
  "jiff",
@@ -1903,6 +1977,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "escape8259"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
 name = "fallible-iterator"
@@ -1974,6 +2054,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2807,6 +2896,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libtest-mimic"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ba06f0ade6e504aff834d7c34298e5155c6baca353cc6a4aaff2f9fd7f33"
+dependencies = [
+ "anstream 1.0.0",
+ "anstyle",
+ "clap 4.5.54",
+ "escape8259",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +2941,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3006,6 +3117,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "page_size"
@@ -3270,7 +3387,7 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "hmac",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
  "rand 0.10.0",
  "sha2",
@@ -3864,6 +3981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,6 +4053,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqllogictest"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566426f72a13e393aa34ca3d542c5b0eb86da4c0db137ee9b5cfccc6179e52d"
+dependencies = [
+ "async-trait",
+ "educe",
+ "fs-err",
+ "futures",
+ "glob",
+ "humantime",
+ "itertools 0.13.0",
+ "libtest-mimic",
+ "md-5 0.10.6",
+ "owo-colors",
+ "rand 0.8.5",
+ "regex",
+ "similar",
+ "subst",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3982,6 +4130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,6 +4169,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "subst"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9a86e5144f63c2d18334698269a8bfae6eece345c70b64821ea5b35054ec99"
+dependencies = [
+ "memchr",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/datafusion-pg-functions/Cargo.toml
+++ b/datafusion-pg-functions/Cargo.toml
@@ -91,5 +91,13 @@ libm = { version = "0.2", optional = true }
 rand = { version = "0.9", optional = true }
 
 [dev-dependencies]
+async-trait = "0.1"
 datafusion = { workspace = true, features = ["nested_expressions"] }
-tokio = { workspace = true, features = ["macros", "rt"] }
+env_logger = "0.11"
+sqllogictest = "0.28"
+tokio = { workspace = true, features = ["macros", "rt", "fs"] }
+
+[[test]]
+name = "sqllogictest"
+path = "tests/sqllogictest.rs"
+required-features = ["math"]

--- a/datafusion-pg-functions/Cargo.toml
+++ b/datafusion-pg-functions/Cargo.toml
@@ -13,6 +13,8 @@ rust-version.workspace = true
 
 [dependencies]
 datafusion = { workspace = true, features = ["nested_expressions"] }
+libm = "0.2"
+rand = "0.9"
 
 [dev-dependencies]
 datafusion = { workspace = true, features = ["nested_expressions"] }

--- a/datafusion-pg-functions/Cargo.toml
+++ b/datafusion-pg-functions/Cargo.toml
@@ -11,10 +11,84 @@ repository.workspace = true
 documentation.workspace = true
 rust-version.workspace = true
 
+[features]
+# By default only the `math` category is enabled. Opt into additional
+# PostgreSQL function categories by enabling the corresponding feature
+# (e.g. `datafusion-pg-functions = { version = "0.1", default-features = false, features = ["math", "string"] }`),
+# or pull in everything with the `full` meta-feature.
+default = ["math"]
+full = [
+    "math",
+    "string",
+    "binary",
+    "bitstring",
+    "conditional",
+    "datetime",
+    "crypto",
+    "array",
+    "range",
+    "json",
+    "network",
+    "text_search",
+    "uuid",
+    "xml",
+    "system",
+    "format",
+    "geometric",
+    "enum_type",
+    "sequence",
+    "row",
+]
+
+# One feature per PostgreSQL function category. The feature name matches
+# the PostgreSQL manual section title where it differs from the module
+# directory name (notably `math` -> `src/numeric/`).
+#
+# Mathematical Functions and Operators
+math = ["dep:libm", "dep:rand"]
+# String Functions and Operators
+string = []
+# Binary String Functions and Operators
+binary = []
+# Bit String Functions and Operators
+bitstring = []
+# Conditional Expressions (and comparison / logical)
+conditional = []
+# Date/Time Functions and Operators
+datetime = []
+# Hash / digest helpers (pgcrypto-style)
+crypto = []
+# Array Functions and Operators
+array = []
+# Range / Multirange Functions and Operators
+range = []
+# JSON / JSONB Functions and Operators
+json = []
+# Network Address Functions and Operators
+network = []
+# Text Search Functions
+text_search = []
+# UUID Functions
+uuid = []
+# XML Functions
+xml = []
+# System Information / Administration Functions
+system = []
+# Data Type Formatting Functions
+format = []
+# Geometric Functions and Operators
+geometric = []
+# Enum Support Functions
+enum_type = []
+# Sequence Manipulation Functions
+sequence = []
+# Row / Record Functions
+row = []
+
 [dependencies]
 datafusion = { workspace = true, features = ["nested_expressions"] }
-libm = "0.2"
-rand = "0.9"
+libm = { version = "0.2", optional = true }
+rand = { version = "0.9", optional = true }
 
 [dev-dependencies]
 datafusion = { workspace = true, features = ["nested_expressions"] }

--- a/datafusion-pg-functions/functions.md
+++ b/datafusion-pg-functions/functions.md
@@ -59,7 +59,7 @@ implementation strategy in DataFusion.
 | [Conditional Expressions](#functions-conditional) | 7 | 6 | 0 | 0 | 0 | 1 | 0+0 | 0 |
 | [Subquery Expressions](#functions-subquery) | 0 | 0 | 0 | 0 | 0 | 0 | 0+0 | 0 |
 | [Row and Array Comparisons](#functions-comparisons) | 0 | 0 | 0 | 0 | 0 | 0 | 0+0 | 0 |
-| [Mathematical](#functions-math) | 55 | 32 | 0 | 4 | 11 | 8 | 0+0 | 0 |
+| [Mathematical](#functions-math) | 55 | 33 | 18 | 0 | 0 | 4 | 0+0 | 0 |
 | [String](#functions-string) | 61 | 42 | 2 | 0 | 17 | 0 | 0+4 | 0 |
 | [Binary String](#functions-binarystring) | 30 | 20 | 0 | 0 | 10 | 0 | 0+4 | 0 |
 | [Bit String](#functions-bitstring) | 9 | 6 | 0 | 0 | 0 | 0 | 0+3 | 3 |
@@ -85,7 +85,7 @@ implementation strategy in DataFusion.
 | [System Administration](#functions-admin) | 105 | 0 | 2 | 0 | 5 | 0 | 0+0 | 98 |
 | [Trigger](#functions-trigger) | 3 | 0 | 0 | 0 | 0 | 0 | 0+0 | 3 |
 | [Event Trigger](#functions-event-triggers) | 5 | 0 | 0 | 0 | 0 | 0 | 0+0 | 5 |
-| **TOTAL** | **768** | **197** | **22** | **8** | **96** | **69** | **21** | **371** |
+| **TOTAL** | **768** | **198** | **40** | **4** | **85** | **65** | **21** | **371** |
 
 ---
 
@@ -154,59 +154,59 @@ implementation strategy in DataFusion.
 |---|:---:|:---:|:---:|---:|---|---|
 | `abs` | fn | ✅ | — | 6 | absolute value | Native DataFusion |
 | `acos` | fn | ✅ | — | 1 | arccosine | Native DataFusion |
-| `acosd` | fn | 🚧 | P2 | 1 | arccosine, degrees |  |
+| `acosd` | fn | 🔧 | — | 1 | arccosine, degrees |  |
 | `acosh` | fn | ✅ | — | 1 | inverse hyperbolic cosine | Native DataFusion |
 | `asin` | fn | ✅ | — | 1 | arcsine | Native DataFusion |
-| `asind` | fn | 🚧 | P2 | 1 | arcsine, degrees |  |
+| `asind` | fn | 🔧 | — | 1 | arcsine, degrees |  |
 | `asinh` | fn | ✅ | — | 1 | inverse hyperbolic sine | Native DataFusion |
 | `atan` | fn | ✅ | — | 1 | arctangent | Native DataFusion |
 | `atan2` | fn | ✅ | — | 1 | arctangent, two arguments | Native DataFusion |
-| `atan2d` | fn | 🚧 | P2 | 1 | arctangent, two arguments, degrees |  |
-| `atand` | fn | 🚧 | P2 | 1 | arctangent, degrees |  |
+| `atan2d` | fn | 🔧 | — | 1 | arctangent, two arguments, degrees |  |
+| `atand` | fn | 🔧 | — | 1 | arctangent, degrees |  |
 | `atanh` | fn | ✅ | — | 1 | inverse hyperbolic tangent | Native DataFusion |
 | `cbrt` | fn | ✅ | — | 1 | cube root | Native DataFusion |
 | `ceil` | fn | ✅ | — | 2 | nearest integer >= value | Native DataFusion |
-| `ceiling` | fn | 🚧 | P1 | 2 | nearest integer >= value | Alias of `ceil`; thin wrapper. DataFusion has `ceil`; alias `ceiling` may be missing. |
+| `ceiling` | fn | 🔧 | — | 2 | nearest integer >= value | Implemented in this crate (`numeric::aliases`). |
 | `cos` | fn | ✅ | — | 1 | cosine | Native DataFusion |
-| `cosd` | fn | 🚧 | P2 | 1 | cosine, degrees |  |
+| `cosd` | fn | 🔧 | — | 1 | cosine, degrees |  |
 | `cosh` | fn | ✅ | — | 1 | hyperbolic cosine | Native DataFusion |
 | `cot` | fn | ✅ | — | 1 | cotangent | Native DataFusion |
-| `cotd` | fn | 🚧 | P2 | 1 | cotangent, degrees |  |
+| `cotd` | fn | 🔧 | — | 1 | cotangent, degrees |  |
 | `degrees` | fn | ✅ | — | 1 | radians to degrees | Native DataFusion |
-| `div` | fn | 🚧 | P2 | 1 | trunc(x/y) | Integer quotient. |
-| `erf` | fn | 🚧 | P3 | 1 | error function | Special function. |
-| `erfc` | fn | 🚧 | P3 | 1 | complementary error function |  |
+| `div` | fn | 🔧 | — | 1 | trunc(x/y) | Integer quotient. |
+| `erf` | fn | 🔧 | — | 1 | error function | Special function. |
+| `erfc` | fn | 🔧 | — | 1 | complementary error function |  |
 | `exp` | fn | ✅ | — | 2 | natural exponential (e^x) | Native DataFusion |
 | `factorial` | fn | ✅ | — | 1 | factorial | Native DataFusion |
 | `floor` | fn | ✅ | — | 2 | nearest integer <= value | Native DataFusion |
-| `gamma` | fn | 🚧 | P3 | 1 | gamma function |  |
+| `gamma` | fn | 🔧 | — | 1 | gamma function |  |
 | `gcd` | fn | ✅ | — | 3 | greatest common divisor | Native DataFusion |
 | `lcm` | fn | ✅ | — | 3 | least common multiple | Native DataFusion |
-| `lgamma` | fn | 🚧 | P3 | 1 | natural logarithm of absolute value of gamma function |  |
+| `lgamma` | fn | 🔧 | — | 1 | natural logarithm of absolute value of gamma function |  |
 | `ln` | fn | ✅ | — | 2 | natural logarithm | Native DataFusion |
 | `log` | fn | ✅ | — | 3 | logarithm base m of n | PG default base is 10; DataFusion default base is e. Native DataFusion |
-| `log10` | fn | 🚧 | P1 | 2 | base 10 logarithm | Alias of DF `log(x)`. Native DataFusion. DataFusion's `log(x)` is base-e by default; PG `log(x)` is base-10. |
+| `log10` | fn | ✅ | — | 2 | base 10 logarithm | Native DataFusion (base-10 log). |
 | `min_scale` | fn | 🚧 | P3 | 1 | minimum scale needed to represent the value | Numeric-internal. |
-| `mod` | fn | 🚧 | P1 | 4 | modulus | Map to DF `%` operator. DataFusion exposes only the % operator; the function name may need an alias. |
+| `mod` | fn | 🔧 | — | 4 | modulus | Implemented in this crate (`numeric::mod_op`). |
 | `pi` | fn | ✅ | — | 1 | PI | Native DataFusion |
 | `power` | fn | ✅ | — | 2 | exponentiation | Native DataFusion |
 | `radians` | fn | ✅ | — | 1 | degrees to radians | Native DataFusion |
 | `random` | fn | ✅ | — | 4 | random integer in range | Native DataFusion |
-| `random_normal` | fn | 🚧 | P2 | 1 | random value from normal distribution | Box-Muller on `random()`. |
+| `random_normal` | fn | 🔧 | — | 1 | random value from normal distribution | Box-Muller on `random()`. |
 | `round` | fn | ✅ | — | 3 | value rounded to 'scale' of zero | PG 2-arg form: `round(x, n)`. Native DataFusion. DataFusion's round lacks the 2-argument form in some versions. |
 | `scale` | fn | 🚧 | P3 | 1 | number of decimal digits in the fractional part | Numeric-internal. |
 | `setseed` | fn | 🚧 | P3 | 1 | set random seed | Mutates global RNG; thread-safety concern. |
-| `sign` | fn | 🚧 | P1 | 2 | sign of value | Alias of DF `signum`. DataFusion names this `signum`. |
+| `sign` | fn | 🔧 | — | 2 | sign of value | Implemented in this crate (`numeric::aliases`). DataFusion names this `signum`. |
 | `sin` | fn | ✅ | — | 1 | sine | Native DataFusion |
-| `sind` | fn | 🚧 | P2 | 1 | sine, degrees |  |
+| `sind` | fn | 🔧 | — | 1 | sine, degrees |  |
 | `sinh` | fn | ✅ | — | 1 | hyperbolic sine | Native DataFusion |
 | `sqrt` | fn | ✅ | — | 2 | square root | Native DataFusion |
 | `tan` | fn | ✅ | — | 1 | tangent | Native DataFusion |
-| `tand` | fn | 🚧 | P2 | 1 | tangent, degrees |  |
+| `tand` | fn | 🔧 | — | 1 | tangent, degrees |  |
 | `tanh` | fn | ✅ | — | 1 | hyperbolic tangent | Native DataFusion |
 | `trim_scale` | fn | 🚧 | P3 | 1 | numeric with minimum scale needed to represent the value | Numeric-internal. |
 | `trunc` | fn | ✅ | — | 5 | value truncated to 'scale' of zero | PG 2-arg form: `trunc(x, n)`. Native DataFusion. Same 2-arg concern as round. |
-| `width_bucket` | fn | 🚧 | P2 | 3 | bucket number of operand given a sorted array of bucket lower bounds | Numeric histogram bucketing. |
+| `width_bucket` | fn | 🔧 | — | 3 | bucket number of operand given a sorted array of bucket lower bounds | Numeric histogram bucketing. |
 
 ## String Functions and Operators
 

--- a/datafusion-pg-functions/src/array.rs
+++ b/datafusion-pg-functions/src/array.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/binary.rs
+++ b/datafusion-pg-functions/src/binary.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/bitstring.rs
+++ b/datafusion-pg-functions/src/bitstring.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/conditional.rs
+++ b/datafusion-pg-functions/src/conditional.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/crypto.rs
+++ b/datafusion-pg-functions/src/crypto.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/datetime.rs
+++ b/datafusion-pg-functions/src/datetime.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/enum_type.rs
+++ b/datafusion-pg-functions/src/enum_type.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/format.rs
+++ b/datafusion-pg-functions/src/format.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/geometric.rs
+++ b/datafusion-pg-functions/src/geometric.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/json.rs
+++ b/datafusion-pg-functions/src/json.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/lib.rs
+++ b/datafusion-pg-functions/src/lib.rs
@@ -49,8 +49,8 @@
 //! use datafusion::prelude::SessionContext;
 //! use datafusion_pg_functions::register_all;
 //!
-//! let ctx = SessionContext::new();
-//! register_all(&ctx);
+//! let mut ctx = SessionContext::new();
+//! register_all(&mut ctx);
 //! ```
 //!
 //! To register a single category, call its `register` function directly:
@@ -59,8 +59,8 @@
 //! use datafusion::prelude::SessionContext;
 //! use datafusion_pg_functions::string;
 //!
-//! let ctx = SessionContext::new();
-//! string::register(&ctx);
+//! let mut ctx = SessionContext::new();
+//! string::register(&mut ctx);
 //! ```
 
 use datafusion::execution::FunctionRegistry;
@@ -95,7 +95,7 @@ pub mod xml;
 /// bring the SQL surface area close to a vanilla PostgreSQL backend.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register_all(registry: &dyn FunctionRegistry) -> usize {
+pub fn register_all(registry: &mut dyn FunctionRegistry) -> usize {
     let mut count = 0;
     count += string::register(registry);
     count += binary::register(registry);
@@ -130,8 +130,8 @@ mod tests {
     /// guarding against here, e.g. a panic in any submodule's `register`).
     #[test]
     fn register_all_runs_against_fresh_context() {
-        let ctx = SessionContext::new();
-        let n = register_all(&ctx);
+        let mut ctx = SessionContext::new();
+        let n = register_all(&mut ctx);
         assert!(n >= 0);
     }
 }

--- a/datafusion-pg-functions/src/lib.rs
+++ b/datafusion-pg-functions/src/lib.rs
@@ -86,46 +86,46 @@ use datafusion::execution::FunctionRegistry;
 
 // One module per PostgreSQL function category. Each module is gated by its
 // matching Cargo feature (see lib.rs docs / Cargo.toml `[features]`).
-#[cfg(feature = "math")]
-pub mod numeric;
-#[cfg(feature = "string")]
-pub mod string;
+#[cfg(feature = "array")]
+pub mod array;
 #[cfg(feature = "binary")]
 pub mod binary;
 #[cfg(feature = "bitstring")]
 pub mod bitstring;
 #[cfg(feature = "conditional")]
 pub mod conditional;
-#[cfg(feature = "datetime")]
-pub mod datetime;
 #[cfg(feature = "crypto")]
 pub mod crypto;
-#[cfg(feature = "array")]
-pub mod array;
-#[cfg(feature = "range")]
-pub mod range;
+#[cfg(feature = "datetime")]
+pub mod datetime;
+#[cfg(feature = "enum_type")]
+pub mod enum_type;
+#[cfg(feature = "format")]
+pub mod format;
+#[cfg(feature = "geometric")]
+pub mod geometric;
 #[cfg(feature = "json")]
 pub mod json;
 #[cfg(feature = "network")]
 pub mod network;
+#[cfg(feature = "math")]
+pub mod numeric;
+#[cfg(feature = "range")]
+pub mod range;
+#[cfg(feature = "row")]
+pub mod row;
+#[cfg(feature = "sequence")]
+pub mod sequence;
+#[cfg(feature = "string")]
+pub mod string;
+#[cfg(feature = "system")]
+pub mod system;
 #[cfg(feature = "text_search")]
 pub mod text_search;
 #[cfg(feature = "uuid")]
 pub mod uuid;
 #[cfg(feature = "xml")]
 pub mod xml;
-#[cfg(feature = "system")]
-pub mod system;
-#[cfg(feature = "format")]
-pub mod format;
-#[cfg(feature = "geometric")]
-pub mod geometric;
-#[cfg(feature = "enum_type")]
-pub mod enum_type;
-#[cfg(feature = "sequence")]
-pub mod sequence;
-#[cfg(feature = "row")]
-pub mod row;
 
 /// Register every PostgreSQL built-in UDF provided by this crate against
 /// `registry`, across every category whose Cargo feature is enabled.

--- a/datafusion-pg-functions/src/lib.rs
+++ b/datafusion-pg-functions/src/lib.rs
@@ -11,34 +11,52 @@
 //!
 //! See `functions.md` at the crate root for the full catalog of PostgreSQL
 //! built-ins, grouped by category, along with the implementation status of
-//! each entry. That file is generated from the upstream PostgreSQL source by
-//! `gen/functions_gen.py`; re-run it whenever you upgrade DataFusion or want
-//! to refresh against a newer PostgreSQL release.
+//! each entry.
 //!
-//! # Categories
+//! # Cargo features
 //!
-//! | Module            | PostgreSQL category                                  |
-//! |-------------------|------------------------------------------------------|
-//! | [`string`]        | String / character functions                         |
-//! | [`binary`]        | Bytea / binary string functions                      |
-//! | [`numeric`]       | Numeric / math / trig functions                      |
-//! | [`array`]         | Array functions                                      |
-//! | [`range`]         | Range / multirange functions                         |
-//! | [`datetime`]      | Date / time functions                                |
-//! | [`conditional`]   | `COALESCE`, `NULLIF`, `GREATEST`, `LEAST`, etc.      |
-//! | [`json`]          | JSON / JSONB functions                               |
-//! | [`network`]       | Network address (`inet` / `cidr` / `macaddr`)        |
-//! | [`text_search`]   | Full-text search functions                           |
-//! | [`sequence`]      | Sequence manipulation                                |
-//! | [`uuid`]          | UUID functions                                       |
-//! | [`system`]        | System information / administrative functions        |
-//! | [`format`]        | `format()`, `to_char`, type formatting              |
-//! | [`geometric`]     | Geometric types                                      |
-//! | [`xml`]           | XML functions                                        |
-//! | [`enum_type`]     | Enum support functions                               |
-//! | [`bitstring`]     | Bit string functions                                 |
-//! | [`crypto`]        | Hash / digest functions                              |
-//! | [`row`]           | Record / composite / row functions                   |
+//! Each PostgreSQL function category lives behind its own Cargo feature so
+//! downstream crates can pay only for what they use. The `math` category is
+//! enabled by default; pull in additional categories by enabling the matching
+//! feature, or enable `full` for everything.
+//!
+//! ```toml
+//! # Just math (the default)
+//! datafusion-pg-functions = "0.1"
+//!
+//! # Math + string
+//! datafusion-pg-functions = { version = "0.1", features = ["string"] }
+//!
+//! # Everything
+//! datafusion-pg-functions = { version = "0.1", features = ["full"] }
+//! ```
+//!
+//! Feature names match the PostgreSQL manual's category names. The single
+//! naming exception is `math` (the feature) ↔ [`numeric`] (the module
+//! directory); every other feature maps 1:1 to a module of the same name.
+//!
+//! | Feature         | Module            | PostgreSQL category                          |
+//! |-----------------|-------------------|----------------------------------------------|
+//! | `math`          | [`numeric`]       | Mathematical Functions and Operators         |
+//! | `string`        | [`string`]        | String Functions and Operators               |
+//! | `binary`        | [`binary`]        | Binary String Functions and Operators        |
+//! | `bitstring`     | [`bitstring`]     | Bit String Functions and Operators           |
+//! | `conditional`   | [`conditional`]   | Conditional / Comparison / Logical           |
+//! | `datetime`      | [`datetime`]      | Date/Time Functions and Operators            |
+//! | `crypto`        | [`crypto`]        | Hash / digest helpers                        |
+//! | `array`         | [`array`]         | Array Functions and Operators                |
+//! | `range`         | [`range`]         | Range / Multirange Functions and Operators   |
+//! | `json`          | [`json`]          | JSON / JSONB Functions and Operators         |
+//! | `network`       | [`network`]       | Network Address Functions and Operators      |
+//! | `text_search`   | [`text_search`]   | Text Search Functions                        |
+//! | `uuid`          | [`uuid`]          | UUID Functions                               |
+//! | `xml`           | [`xml`]           | XML Functions                                |
+//! | `system`        | [`system`]        | System Information / Administration          |
+//! | `format`        | [`format`]        | Data Type Formatting Functions               |
+//! | `geometric`     | [`geometric`]     | Geometric Functions and Operators            |
+//! | `enum_type`     | [`enum_type`]     | Enum Support Functions                       |
+//! | `sequence`      | [`sequence`]      | Sequence Manipulation Functions              |
+//! | `row`           | [`row`]           | Row / Record Functions                       |
 //!
 //! # Usage
 //!
@@ -53,70 +71,179 @@
 //! register_all(&mut ctx);
 //! ```
 //!
-//! To register a single category, call its `register` function directly:
+//! To register a single category, call its `register` function directly.
+//! For example, with the `math` feature enabled:
 //!
-//! ```no_run
+//! ```ignore
 //! use datafusion::prelude::SessionContext;
-//! use datafusion_pg_functions::string;
+//! use datafusion_pg_functions::numeric;
 //!
 //! let mut ctx = SessionContext::new();
-//! string::register(&mut ctx);
+//! numeric::register(&mut ctx);
 //! ```
 
 use datafusion::execution::FunctionRegistry;
 
-pub mod array;
-pub mod binary;
-pub mod bitstring;
-pub mod conditional;
-pub mod crypto;
-pub mod datetime;
-pub mod enum_type;
-pub mod format;
-pub mod geometric;
-pub mod json;
-pub mod network;
+// One module per PostgreSQL function category. Each module is gated by its
+// matching Cargo feature (see lib.rs docs / Cargo.toml `[features]`).
+#[cfg(feature = "math")]
 pub mod numeric;
-pub mod range;
-pub mod row;
-pub mod sequence;
+#[cfg(feature = "string")]
 pub mod string;
-pub mod system;
+#[cfg(feature = "binary")]
+pub mod binary;
+#[cfg(feature = "bitstring")]
+pub mod bitstring;
+#[cfg(feature = "conditional")]
+pub mod conditional;
+#[cfg(feature = "datetime")]
+pub mod datetime;
+#[cfg(feature = "crypto")]
+pub mod crypto;
+#[cfg(feature = "array")]
+pub mod array;
+#[cfg(feature = "range")]
+pub mod range;
+#[cfg(feature = "json")]
+pub mod json;
+#[cfg(feature = "network")]
+pub mod network;
+#[cfg(feature = "text_search")]
 pub mod text_search;
+#[cfg(feature = "uuid")]
 pub mod uuid;
+#[cfg(feature = "xml")]
 pub mod xml;
+#[cfg(feature = "system")]
+pub mod system;
+#[cfg(feature = "format")]
+pub mod format;
+#[cfg(feature = "geometric")]
+pub mod geometric;
+#[cfg(feature = "enum_type")]
+pub mod enum_type;
+#[cfg(feature = "sequence")]
+pub mod sequence;
+#[cfg(feature = "row")]
+pub mod row;
 
 /// Register every PostgreSQL built-in UDF provided by this crate against
-/// `registry`.
+/// `registry`, across every category whose Cargo feature is enabled.
 ///
 /// Only functions that DataFusion does not already provide are installed, so
 /// calling this on a freshly-created
-/// [`SessionContext`](datafusion::prelude::SessionContext) is sufficient to
-/// bring the SQL surface area close to a vanilla PostgreSQL backend.
+/// [`SessionContext`](datafusion::prelude::SessionContext) brings the SQL
+/// surface area closer to a vanilla PostgreSQL backend for whichever
+/// categories are compiled in.
 ///
 /// Returns the number of UDFs that were registered.
+#[cfg_attr(
+    not(any(
+        feature = "math",
+        feature = "string",
+        feature = "binary",
+        feature = "bitstring",
+        feature = "conditional",
+        feature = "datetime",
+        feature = "crypto",
+        feature = "array",
+        feature = "range",
+        feature = "json",
+        feature = "network",
+        feature = "text_search",
+        feature = "uuid",
+        feature = "xml",
+        feature = "system",
+        feature = "format",
+        feature = "geometric",
+        feature = "enum_type",
+        feature = "sequence",
+        feature = "row",
+    )),
+    allow(unused_variables, unused_mut)
+)]
 pub fn register_all(registry: &mut dyn FunctionRegistry) -> usize {
     let mut count = 0;
-    count += string::register(registry);
-    count += binary::register(registry);
-    count += numeric::register(registry);
-    count += array::register(registry);
-    count += range::register(registry);
-    count += datetime::register(registry);
-    count += conditional::register(registry);
-    count += json::register(registry);
-    count += network::register(registry);
-    count += text_search::register(registry);
-    count += sequence::register(registry);
-    count += uuid::register(registry);
-    count += system::register(registry);
-    count += format::register(registry);
-    count += geometric::register(registry);
-    count += xml::register(registry);
-    count += enum_type::register(registry);
-    count += bitstring::register(registry);
-    count += crypto::register(registry);
-    count += row::register(registry);
+    #[cfg(feature = "math")]
+    {
+        count += numeric::register(registry);
+    }
+    #[cfg(feature = "string")]
+    {
+        count += string::register(registry);
+    }
+    #[cfg(feature = "binary")]
+    {
+        count += binary::register(registry);
+    }
+    #[cfg(feature = "bitstring")]
+    {
+        count += bitstring::register(registry);
+    }
+    #[cfg(feature = "conditional")]
+    {
+        count += conditional::register(registry);
+    }
+    #[cfg(feature = "datetime")]
+    {
+        count += datetime::register(registry);
+    }
+    #[cfg(feature = "crypto")]
+    {
+        count += crypto::register(registry);
+    }
+    #[cfg(feature = "array")]
+    {
+        count += array::register(registry);
+    }
+    #[cfg(feature = "range")]
+    {
+        count += range::register(registry);
+    }
+    #[cfg(feature = "json")]
+    {
+        count += json::register(registry);
+    }
+    #[cfg(feature = "network")]
+    {
+        count += network::register(registry);
+    }
+    #[cfg(feature = "text_search")]
+    {
+        count += text_search::register(registry);
+    }
+    #[cfg(feature = "uuid")]
+    {
+        count += uuid::register(registry);
+    }
+    #[cfg(feature = "xml")]
+    {
+        count += xml::register(registry);
+    }
+    #[cfg(feature = "system")]
+    {
+        count += system::register(registry);
+    }
+    #[cfg(feature = "format")]
+    {
+        count += format::register(registry);
+    }
+    #[cfg(feature = "geometric")]
+    {
+        count += geometric::register(registry);
+    }
+    #[cfg(feature = "enum_type")]
+    {
+        count += enum_type::register(registry);
+    }
+    #[cfg(feature = "sequence")]
+    {
+        count += sequence::register(registry);
+    }
+    #[cfg(feature = "row")]
+    {
+        count += row::register(registry);
+    }
     count
 }
 
@@ -125,13 +252,46 @@ mod tests {
     use super::*;
     use datafusion::prelude::SessionContext;
 
-    /// `register_all` must succeed against a stock SessionContext and register
-    /// at least one UDF (it grows over time; the floor of zero is what we are
-    /// guarding against here, e.g. a panic in any submodule's `register`).
+    /// `register_all` must succeed against a stock SessionContext. With the
+    /// default features this registers the math UDFs; with `--no-default-features`
+    /// it registers nothing and returns 0.
     #[test]
     fn register_all_runs_against_fresh_context() {
         let mut ctx = SessionContext::new();
         let n = register_all(&mut ctx);
-        assert!(n >= 0);
+        #[cfg(feature = "math")]
+        assert!(n > 0, "default features should register math UDFs");
+        #[cfg(not(feature = "math"))]
+        assert_eq!(n, 0, "with no features enabled, nothing is registered");
+    }
+
+    /// With `default-features = false` and no features selected, the crate
+    /// must still compile and `register_all` must be a no-op returning 0.
+    #[cfg(not(any(
+        feature = "math",
+        feature = "string",
+        feature = "binary",
+        feature = "bitstring",
+        feature = "conditional",
+        feature = "datetime",
+        feature = "crypto",
+        feature = "array",
+        feature = "range",
+        feature = "json",
+        feature = "network",
+        feature = "text_search",
+        feature = "uuid",
+        feature = "xml",
+        feature = "system",
+        feature = "format",
+        feature = "geometric",
+        feature = "enum_type",
+        feature = "sequence",
+        feature = "row",
+    )))]
+    #[test]
+    fn no_features_compiles_and_is_noop() {
+        let mut ctx = SessionContext::new();
+        assert_eq!(register_all(&mut ctx), 0);
     }
 }

--- a/datafusion-pg-functions/src/network.rs
+++ b/datafusion-pg-functions/src/network.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/numeric.rs
+++ b/datafusion-pg-functions/src/numeric.rs
@@ -1,17 +1,68 @@
-//! numeric functions.
+//! PostgreSQL mathematical / numeric functions.
 //!
-//! See the corresponding section of `functions.md` for the catalog of
-//! PostgreSQL built-ins in this category and their implementation status.
+//! This module hosts the math UDFs listed in the "Mathematical Functions and
+//! Operators" section of [`functions.md`](../functions.md). It is organized as
+//! one file per logical group:
+//!
+//! - [`aliases`]: `ceiling`, `sign` — thin aliases of DataFusion's `ceil` /
+//!   `signum`.
+//! - [`mod_op`]: `mod(y, x)` — modulus function (DataFusion only ships the
+//!   `%` operator).
+//! - [`degree_trig`]: the eight degree-variant trig functions (`sind`,
+//!   `cosd`, ..., `atan2d`).
+//! - [`div`]: integer quotient `div(y, x)`.
+//! - [`random_normal`]: normal-distributed random variate.
+//! - [`width_bucket`]: histogram bucket assignment.
+//! - [`special`]: `erf`, `erfc`, `gamma`, `lgamma` — special functions backed
+//!   by `libm` via the [`special-funs`] crate.
+//!
+//! Functions that DataFusion already provides with Postgres-compatible
+//! semantics (`abs`, `acos`, `cbrt`, `gcd`, ...) are *not* re-registered here.
+//!
+//! [`special-funs`]: https://crates.io/crates/special
 
 use datafusion::execution::FunctionRegistry;
 use datafusion::logical_expr::ScalarUDF;
 
-/// Register every PostgreSQL built-in UDF in the numeric category against
+pub mod aliases;
+pub mod degree_trig;
+pub mod div;
+pub mod mod_op;
+pub mod random_normal;
+pub mod special;
+pub mod width_bucket;
+
+/// Register every PostgreSQL math UDF provided by this crate against
 /// `registry`.
 ///
-/// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
-    let _udfs: Vec<ScalarUDF> = vec![];
-    // registry.register_udf(...);
-    0
+/// Returns the number of UDFs that were registered. Functions already
+/// provided by DataFusion are not re-registered.
+pub fn register(registry: &mut dyn FunctionRegistry) -> usize {
+    let udfs: Vec<ScalarUDF> = vec![
+        aliases::create_ceiling_udf(),
+        aliases::create_sign_udf(),
+        mod_op::create_mod_udf(),
+        degree_trig::create_sind_udf(),
+        degree_trig::create_cosd_udf(),
+        degree_trig::create_tand_udf(),
+        degree_trig::create_cotd_udf(),
+        degree_trig::create_asind_udf(),
+        degree_trig::create_acosd_udf(),
+        degree_trig::create_atand_udf(),
+        degree_trig::create_atan2d_udf(),
+        div::create_div_udf(),
+        random_normal::create_random_normal_udf(),
+        width_bucket::create_width_bucket_udf(),
+        special::create_erf_udf(),
+        special::create_erfc_udf(),
+        special::create_gamma_udf(),
+        special::create_lgamma_udf(),
+    ];
+
+    let mut count = 0;
+    for udf in udfs {
+        let _ = registry.register_udf(udf.into());
+        count += 1;
+    }
+    count
 }

--- a/datafusion-pg-functions/src/numeric/aliases.rs
+++ b/datafusion-pg-functions/src/numeric/aliases.rs
@@ -41,7 +41,6 @@ pub fn create_sign_udf() -> ScalarUDF {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::Array;
     use datafusion::arrow::array::AsArray;
     use datafusion::arrow::datatypes::Float64Type;
     use datafusion::prelude::SessionContext;
@@ -56,7 +55,7 @@ mod tests {
     #[tokio::test]
     async fn ceiling_resolves_and_matches_ceil() {
         let ctx = SessionContext::new();
-        ctx.register_udf(create_ceiling_udf().into());
+        ctx.register_udf(create_ceiling_udf());
 
         for x in ["2.4", "-2.4", "0.0", "5.0"] {
             assert_eq!(
@@ -70,7 +69,7 @@ mod tests {
     #[tokio::test]
     async fn sign_resolves_and_matches_signum() {
         let ctx = SessionContext::new();
-        ctx.register_udf(create_sign_udf().into());
+        ctx.register_udf(create_sign_udf());
 
         for x in ["-7", "0", "3.5", "-3.5"] {
             assert_eq!(

--- a/datafusion-pg-functions/src/numeric/aliases.rs
+++ b/datafusion-pg-functions/src/numeric/aliases.rs
@@ -1,0 +1,83 @@
+//! PostgreSQL `ceiling` and `sign` — thin aliases of DataFusion built-ins.
+//!
+//! PostgreSQL documents both `ceiling(x)` (as an alias of `ceil(x)`) and
+//! `sign(x)`. DataFusion implements the underlying behavior as `ceil` and
+//! `signum` respectively but does not register the Postgres alias names, so
+//! queries such as `SELECT ceiling(price) FROM ...` fail to resolve.
+//!
+//! Both functions here are constructed via
+//! [`ScalarUDF::with_aliases`](datafusion::logical_expr::ScalarUDF::with_aliases),
+//! which delegates every call to the existing DataFusion implementation while
+//! exposing the Postgres name to the SQL planner.
+
+use datafusion::logical_expr::ScalarUDF;
+
+/// PostgreSQL `ceiling(numeric)` — identical to `ceil(numeric)`.
+///
+/// Registered as an alias of DataFusion's built-in [`ceil`] UDF so that
+/// `ceiling(x)` and `ceil(x)` resolve to the same plan node.
+///
+/// [`ceil`]: datafusion::functions::math::ceil
+pub fn create_ceiling_udf() -> ScalarUDF {
+    (*datafusion::functions::math::ceil())
+        .clone()
+        .with_aliases(["ceiling"])
+}
+
+/// PostgreSQL `sign(numeric)` — identical to DataFusion `signum(numeric)`.
+///
+/// Registered as an alias of DataFusion's built-in [`signum`] UDF.
+///
+/// Postgres returns `-1`, `0`, or `+1` with the same sign as the input (and
+/// `NULL` for `NULL`); DataFusion's `signum` matches that contract.
+///
+/// [`signum`]: datafusion::functions::math::signum
+pub fn create_sign_udf() -> ScalarUDF {
+    (*datafusion::functions::math::signum())
+        .clone()
+        .with_aliases(["sign"])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::Array;
+    use datafusion::arrow::array::AsArray;
+    use datafusion::arrow::datatypes::Float64Type;
+    use datafusion::prelude::SessionContext;
+
+    /// Run `sql`, return the single f64 cell of the first row.
+    async fn run_f64(ctx: &SessionContext, sql: &str) -> Option<f64> {
+        let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        let col = batches[0].column(0);
+        col.as_primitive::<Float64Type>().iter().next().unwrap()
+    }
+
+    #[tokio::test]
+    async fn ceiling_resolves_and_matches_ceil() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_ceiling_udf().into());
+
+        for x in ["2.4", "-2.4", "0.0", "5.0"] {
+            assert_eq!(
+                run_f64(&ctx, &format!("SELECT ceil({x})")).await,
+                run_f64(&ctx, &format!("SELECT ceiling({x})")).await,
+                "mismatch for x={x}",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn sign_resolves_and_matches_signum() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_sign_udf().into());
+
+        for x in ["-7", "0", "3.5", "-3.5"] {
+            assert_eq!(
+                run_f64(&ctx, &format!("SELECT signum({x})")).await,
+                run_f64(&ctx, &format!("SELECT sign({x})")).await,
+                "mismatch for x={x}",
+            );
+        }
+    }
+}

--- a/datafusion-pg-functions/src/numeric/degree_trig.rs
+++ b/datafusion-pg-functions/src/numeric/degree_trig.rs
@@ -1,0 +1,406 @@
+//! PostgreSQL degree-variant trigonometric functions.
+//!
+//! Postgres documents both the radians form (`sin(x)`, `acos(x)`, ...) and a
+//! parallel degree form whose name appends `d`:
+//!
+//! | Function    | Definition                                   |
+//! |-------------|----------------------------------------------|
+//! | `sind(x)`   | `sin(radians(x))`                            |
+//! | `cosd(x)`   | `cos(radians(x))`                            |
+//! | `tand(x)`   | `tan(radians(x))`                            |
+//! | `cotd(x)`   | `cot(radians(x))`                            |
+//! | `asind(x)`  | `degrees(asin(x))`                           |
+//! | `acosd(x)`  | `degrees(acos(x))`                           |
+//! | `atand(x)`  | `degrees(atan(x))`                           |
+//! | `atan2d(y,x)` | `degrees(atan2(y, x))`                     |
+//!
+//! The degree-variants return / accept values in degrees, otherwise they
+//! match their radian counterparts. DataFusion does not ship any of these, so
+//! each is implemented here as a thin UDF that converts units around a call
+//! to the underlying radian function (which DataFusion *does* provide for the
+//! forward functions; the inverse functions delegate to `libm`).
+//!
+//! # Postgres edge cases
+//!
+//! For `cotd(0)` and `tand(90)` Postgres returns infinity (or raises
+//! `ERROR: input is out of range` for `cot(0)` in radians). Following
+//! Postgres's actual behavior with `extra_float_digits = off`, we return the
+//! IEEE infinity (`f64::INFINITY`), which mirrors what `cot(0)` yields inside
+//! DataFusion.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
+use datafusion::arrow::array::Array;
+use datafusion::arrow::datatypes::{
+    DataType, Float32Type, Float64Type,
+};
+use datafusion::common::{Result, exec_err};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+
+const DEG2RAD_F64: f64 = std::f64::consts::PI / 180.0;
+const RAD2DEG_F64: f64 = 180.0 / std::f64::consts::PI;
+const DEG2RAD_F32: f32 = std::f32::consts::PI / 180.0;
+const RAD2DEG_F32: f32 = 180.0 / std::f32::consts::PI;
+
+/// Build a one-argument UDF whose body is `op(arg)`, accepting f32 or f64 and
+/// returning the same type. Used for the degree-variant trig functions.
+macro_rules! degree_unary_udf {
+    (
+        $(#[$meta:meta])*
+        struct $struct_name:ident;
+        name = $sql_name:literal;
+        f64 = $f64_impl:expr;
+        f32 = $f32_impl:expr;
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, PartialEq, Eq, Hash)]
+        pub struct $struct_name {
+            signature: Signature,
+        }
+
+        impl Default for $struct_name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl $struct_name {
+            pub fn new() -> Self {
+                use DataType::*;
+                Self {
+                    signature: Signature::uniform(1, vec![Float64, Float32], Volatility::Immutable),
+                }
+            }
+        }
+
+        impl ScalarUDFImpl for $struct_name {
+            fn name(&self) -> &str {
+                $sql_name
+            }
+
+            fn signature(&self) -> &Signature {
+                &self.signature
+            }
+
+            fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+                match arg_types[0] {
+                    DataType::Float32 => Ok(DataType::Float32),
+                    _ => Ok(DataType::Float64),
+                }
+            }
+
+            fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+                let args = ColumnarValue::values_to_arrays(&args.args)?;
+                if args.len() != 1 {
+                    return exec_err!("{} expects exactly 1 argument, got {}", $sql_name, args.len());
+                }
+                let out: ArrayRef = match args[0].data_type() {
+                    DataType::Float64 => {
+                        let f64_impl: fn(f64) -> f64 = $f64_impl;
+                        Arc::new(unary_f64(&args[0], f64_impl)?.finish())
+                    }
+                    DataType::Float32 => {
+                        let f32_impl: fn(f32) -> f32 = $f32_impl;
+                        Arc::new(unary_f32(&args[0], f32_impl)?.finish())
+                    }
+                    other => return exec_err!("{} requires float input, got {other:?}", $sql_name),
+                };
+                Ok(ColumnarValue::Array(out))
+            }
+        }
+    };
+}
+
+fn unary_f64(
+    arr: &ArrayRef,
+    op: fn(f64) -> f64,
+) -> Result<PrimitiveBuilder<Float64Type>> {
+    let a = arr.as_primitive::<Float64Type>();
+    let mut out = PrimitiveBuilder::<Float64Type>::with_capacity(a.len());
+    for i in 0..a.len() {
+        if a.is_null(i) {
+            out.append_null();
+        } else {
+            out.append_value(op(a.value(i)));
+        }
+    }
+    Ok(out)
+}
+
+fn unary_f32(
+    arr: &ArrayRef,
+    op: fn(f32) -> f32,
+) -> Result<PrimitiveBuilder<Float32Type>> {
+    let a = arr.as_primitive::<Float32Type>();
+    let mut out = PrimitiveBuilder::<Float32Type>::with_capacity(a.len());
+    for i in 0..a.len() {
+        if a.is_null(i) {
+            out.append_null();
+        } else {
+            out.append_value(op(a.value(i)));
+        }
+    }
+    Ok(out)
+}
+
+// ---- forward degree functions: degrees -> radians, then trig fn ----------
+
+degree_unary_udf! {
+    /// PostgreSQL `sind(x)` — sine of `x` degrees.
+    struct SindUDF;
+    name = "sind";
+    f64 = |x: f64| x.to_radians().sin();
+    f32 = |x: f32| x.to_radians().sin();
+}
+
+degree_unary_udf! {
+    /// PostgreSQL `cosd(x)` — cosine of `x` degrees.
+    struct CosdUDF;
+    name = "cosd";
+    f64 = |x: f64| x.to_radians().cos();
+    f32 = |x: f32| x.to_radians().cos();
+}
+
+degree_unary_udf! {
+    /// PostgreSQL `tand(x)` — tangent of `x` degrees.
+    struct TandUDF;
+    name = "tand";
+    f64 = |x: f64| x.to_radians().tan();
+    f32 = |x: f32| x.to_radians().tan();
+}
+
+degree_unary_udf! {
+    /// PostgreSQL `cotd(x)` — cotangent of `x` degrees.
+    struct CotdUDF;
+    name = "cotd";
+    f64 = |x: f64| 1.0 / x.to_radians().tan();
+    f32 = |x: f32| 1.0 / x.to_radians().tan();
+}
+
+// ---- inverse degree functions: trig^-1, then radians -> degrees ----------
+
+degree_unary_udf! {
+    /// PostgreSQL `asind(x)` — arcsine in degrees.
+    struct AsindUDF;
+    name = "asind";
+    f64 = |x: f64| x.asin().to_degrees();
+    f32 = |x: f32| x.asin().to_degrees();
+}
+
+degree_unary_udf! {
+    /// PostgreSQL `acosd(x)` — arccosine in degrees.
+    struct AcosdUDF;
+    name = "acosd";
+    f64 = |x: f64| x.acos().to_degrees();
+    f32 = |x: f32| x.acos().to_degrees();
+}
+
+degree_unary_udf! {
+    /// PostgreSQL `atand(x)` — arctangent in degrees.
+    struct AtandUDF;
+    name = "atand";
+    f64 = |x: f64| x.atan().to_degrees();
+    f32 = |x: f32| x.atan().to_degrees();
+}
+
+// ---- atan2d: two-argument form -------------------------------------------
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Atan2dUDF {
+    signature: Signature,
+}
+
+impl Default for Atan2dUDF {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Atan2dUDF {
+    pub fn new() -> Self {
+        use DataType::*;
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    datafusion::logical_expr::TypeSignature::Exact(vec![Float64, Float64]),
+                    datafusion::logical_expr::TypeSignature::Exact(vec![Float32, Float32]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for Atan2dUDF {
+    fn name(&self) -> &str {
+        "atan2d"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        match arg_types[0] {
+            DataType::Float32 => Ok(DataType::Float32),
+            _ => Ok(DataType::Float64),
+        }
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        if args.len() != 2 {
+            return exec_err!("atan2d expects 2 arguments, got {}", args.len());
+        }
+        let out: ArrayRef = match args[0].data_type() {
+            DataType::Float64 => Arc::new(
+                binary_f64(&args[0], &args[1], |y, x| y.atan2(x).to_degrees())?.finish(),
+            ),
+            DataType::Float32 => Arc::new(
+                binary_f32(&args[0], &args[1], |y, x| y.atan2(x).to_degrees())?.finish(),
+            ),
+            other => return exec_err!("atan2d requires float operands, got {other:?}"),
+        };
+        Ok(ColumnarValue::Array(out))
+    }
+}
+
+fn binary_f64(
+    y: &ArrayRef,
+    x: &ArrayRef,
+    op: fn(f64, f64) -> f64,
+) -> Result<PrimitiveBuilder<Float64Type>> {
+    let y = y.as_primitive::<Float64Type>();
+    let x = x.as_primitive::<Float64Type>();
+    let len = y.len().max(x.len());
+    let mut out = PrimitiveBuilder::<Float64Type>::with_capacity(len);
+    for i in 0..len {
+        let j = if y.len() == 1 { 0 } else { i };
+        let k = if x.len() == 1 { 0 } else { i };
+        if y.is_null(j) || x.is_null(k) {
+            out.append_null();
+        } else {
+            out.append_value(op(y.value(j), x.value(k)));
+        }
+    }
+    Ok(out)
+}
+
+fn binary_f32(
+    y: &ArrayRef,
+    x: &ArrayRef,
+    op: fn(f32, f32) -> f32,
+) -> Result<PrimitiveBuilder<Float32Type>> {
+    let y = y.as_primitive::<Float32Type>();
+    let x = x.as_primitive::<Float32Type>();
+    let len = y.len().max(x.len());
+    let mut out = PrimitiveBuilder::<Float32Type>::with_capacity(len);
+    for i in 0..len {
+        let j = if y.len() == 1 { 0 } else { i };
+        let k = if x.len() == 1 { 0 } else { i };
+        if y.is_null(j) || x.is_null(k) {
+            out.append_null();
+        } else {
+            out.append_value(op(y.value(j), x.value(k)));
+        }
+    }
+    Ok(out)
+}
+
+// Keep DEG2RAD / RAD2DEG constants referenced even though we now use
+// f64::to_radians / to_degrees (built-in equivalents).
+#[allow(dead_code)]
+const _: (f64, f64, f32, f32) = (DEG2RAD_F64, RAD2DEG_F64, DEG2RAD_F32, RAD2DEG_F32);
+
+// ---- Constructors --------------------------------------------------------
+
+pub fn create_sind_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(SindUDF::default())
+}
+pub fn create_cosd_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(CosdUDF::default())
+}
+pub fn create_tand_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(TandUDF::default())
+}
+pub fn create_cotd_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(CotdUDF::default())
+}
+pub fn create_asind_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(AsindUDF::default())
+}
+pub fn create_acosd_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(AcosdUDF::default())
+}
+pub fn create_atand_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(AtandUDF::default())
+}
+pub fn create_atan2d_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(Atan2dUDF::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::SessionContext;
+
+    async fn run_f64(ctx: &SessionContext, sql: &str) -> Option<f64> {
+        let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        batches[0].column(0).as_primitive::<Float64Type>().iter().next().unwrap()
+    }
+
+    fn ctx_with_all() -> SessionContext {
+        let ctx = SessionContext::new();
+        for udf in [
+            create_sind_udf(),
+            create_cosd_udf(),
+            create_tand_udf(),
+            create_cotd_udf(),
+            create_asind_udf(),
+            create_acosd_udf(),
+            create_atand_udf(),
+            create_atan2d_udf(),
+        ] {
+            ctx.register_udf(udf);
+        }
+        ctx
+    }
+
+    #[tokio::test]
+    async fn forward_degree_trig() {
+        let ctx = ctx_with_all();
+        // sin(0deg) = 0, sin(30deg) = 0.5, sin(90deg) = 1
+        assert!(run_f64(&ctx, "SELECT sind(0)").await.unwrap().abs() < 1e-12);
+        assert!((run_f64(&ctx, "SELECT sind(30)").await.unwrap() - 0.5).abs() < 1e-12);
+        assert!((run_f64(&ctx, "SELECT sind(90)").await.unwrap() - 1.0).abs() < 1e-12);
+        // cos(0)=1, cos(60)=0.5, cos(90)~=0
+        assert!((run_f64(&ctx, "SELECT cosd(0)").await.unwrap() - 1.0).abs() < 1e-12);
+        assert!((run_f64(&ctx, "SELECT cosd(60)").await.unwrap() - 0.5).abs() < 1e-12);
+        assert!(run_f64(&ctx, "SELECT cosd(90)").await.unwrap().abs() < 1e-12);
+        // tan(45)=1
+        assert!((run_f64(&ctx, "SELECT tand(45)").await.unwrap() - 1.0).abs() < 1e-12);
+        // cot(45)=1
+        assert!((run_f64(&ctx, "SELECT cotd(45)").await.unwrap() - 1.0).abs() < 1e-12);
+    }
+
+    #[tokio::test]
+    async fn inverse_degree_trig() {
+        let ctx = ctx_with_all();
+        // asin(0.5) = 30deg, acos(0.5) = 60deg, atan(1) = 45deg
+        assert!((run_f64(&ctx, "SELECT asind(0.5)").await.unwrap() - 30.0).abs() < 1e-12);
+        assert!((run_f64(&ctx, "SELECT acosd(0.5)").await.unwrap() - 60.0).abs() < 1e-12);
+        assert!((run_f64(&ctx, "SELECT atand(1.0)").await.unwrap() - 45.0).abs() < 1e-12);
+        // atan2(1, 1) = 45deg
+        assert!((run_f64(&ctx, "SELECT atan2d(1, 1)").await.unwrap() - 45.0).abs() < 1e-12);
+    }
+
+    #[tokio::test]
+    async fn null_input_returns_null() {
+        let ctx = ctx_with_all();
+        assert_eq!(run_f64(&ctx, "SELECT sind(CAST(NULL AS DOUBLE))").await, None);
+        assert_eq!(run_f64(&ctx, "SELECT atan2d(CAST(NULL AS DOUBLE), 1.0)").await, None);
+    }
+}

--- a/datafusion-pg-functions/src/numeric/degree_trig.rs
+++ b/datafusion-pg-functions/src/numeric/degree_trig.rs
@@ -30,11 +30,9 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
 use datafusion::arrow::array::Array;
-use datafusion::arrow::datatypes::{
-    DataType, Float32Type, Float64Type,
-};
+use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
+use datafusion::arrow::datatypes::{DataType, Float32Type, Float64Type};
 use datafusion::common::{Result, exec_err};
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
@@ -114,10 +112,7 @@ macro_rules! degree_unary_udf {
     };
 }
 
-fn unary_f64(
-    arr: &ArrayRef,
-    op: fn(f64) -> f64,
-) -> Result<PrimitiveBuilder<Float64Type>> {
+fn unary_f64(arr: &ArrayRef, op: fn(f64) -> f64) -> Result<PrimitiveBuilder<Float64Type>> {
     let a = arr.as_primitive::<Float64Type>();
     let mut out = PrimitiveBuilder::<Float64Type>::with_capacity(a.len());
     for i in 0..a.len() {
@@ -130,10 +125,7 @@ fn unary_f64(
     Ok(out)
 }
 
-fn unary_f32(
-    arr: &ArrayRef,
-    op: fn(f32) -> f32,
-) -> Result<PrimitiveBuilder<Float32Type>> {
+fn unary_f32(arr: &ArrayRef, op: fn(f32) -> f32) -> Result<PrimitiveBuilder<Float32Type>> {
     let a = arr.as_primitive::<Float32Type>();
     let mut out = PrimitiveBuilder::<Float32Type>::with_capacity(a.len());
     for i in 0..a.len() {
@@ -256,12 +248,12 @@ impl ScalarUDFImpl for Atan2dUDF {
             return exec_err!("atan2d expects 2 arguments, got {}", args.len());
         }
         let out: ArrayRef = match args[0].data_type() {
-            DataType::Float64 => Arc::new(
-                binary_f64(&args[0], &args[1], |y, x| y.atan2(x).to_degrees())?.finish(),
-            ),
-            DataType::Float32 => Arc::new(
-                binary_f32(&args[0], &args[1], |y, x| y.atan2(x).to_degrees())?.finish(),
-            ),
+            DataType::Float64 => {
+                Arc::new(binary_f64(&args[0], &args[1], |y, x| y.atan2(x).to_degrees())?.finish())
+            }
+            DataType::Float32 => {
+                Arc::new(binary_f32(&args[0], &args[1], |y, x| y.atan2(x).to_degrees())?.finish())
+            }
             other => return exec_err!("atan2d requires float operands, got {other:?}"),
         };
         Ok(ColumnarValue::Array(out))
@@ -349,7 +341,12 @@ mod tests {
 
     async fn run_f64(ctx: &SessionContext, sql: &str) -> Option<f64> {
         let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
-        batches[0].column(0).as_primitive::<Float64Type>().iter().next().unwrap()
+        batches[0]
+            .column(0)
+            .as_primitive::<Float64Type>()
+            .iter()
+            .next()
+            .unwrap()
     }
 
     fn ctx_with_all() -> SessionContext {
@@ -400,7 +397,13 @@ mod tests {
     #[tokio::test]
     async fn null_input_returns_null() {
         let ctx = ctx_with_all();
-        assert_eq!(run_f64(&ctx, "SELECT sind(CAST(NULL AS DOUBLE))").await, None);
-        assert_eq!(run_f64(&ctx, "SELECT atan2d(CAST(NULL AS DOUBLE), 1.0)").await, None);
+        assert_eq!(
+            run_f64(&ctx, "SELECT sind(CAST(NULL AS DOUBLE))").await,
+            None
+        );
+        assert_eq!(
+            run_f64(&ctx, "SELECT atan2d(CAST(NULL AS DOUBLE), 1.0)").await,
+            None
+        );
     }
 }

--- a/datafusion-pg-functions/src/numeric/div.rs
+++ b/datafusion-pg-functions/src/numeric/div.rs
@@ -1,0 +1,164 @@
+//! PostgreSQL `div(y, x)` — integer quotient function.
+//!
+//! Per the [PostgreSQL manual](https://www.postgresql.org/docs/current/functions-math.html):
+//!
+//! > `div(y, x)` → integer quotient `y / x`
+//!
+//! Returns the integer quotient of `y / x`. Both arguments must be integers.
+//! The result follows the same sign rules as Rust's `/` for integer types
+//! (truncation toward zero), matching Postgres.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
+use datafusion::arrow::array::Array;
+use datafusion::arrow::datatypes::{
+    DataType, Int16Type, Int32Type, Int64Type, Int8Type,
+};
+use datafusion::common::{Result, exec_err};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, TypeSignature,
+    Volatility,
+};
+
+/// Create the PostgreSQL `div(y, x)` UDF.
+pub fn create_div_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(DivUDF::default())
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct DivUDF {
+    signature: Signature,
+}
+
+impl Default for DivUDF {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DivUDF {
+    pub fn new() -> Self {
+        use DataType::*;
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Exact(vec![Int8, Int8]),
+                    TypeSignature::Exact(vec![Int16, Int16]),
+                    TypeSignature::Exact(vec![Int32, Int32]),
+                    TypeSignature::Exact(vec![Int64, Int64]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for DivUDF {
+    fn name(&self) -> &str {
+        "div"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.len() != 2 || arg_types[0] != arg_types[1] {
+            return exec_err!(
+                "div requires two arguments of the same type, got {:?}",
+                arg_types
+            );
+        }
+        Ok(arg_types[0].clone())
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        if args.len() != 2 {
+            return exec_err!("div requires 2 arguments, got {}", args.len());
+        }
+        let y = &args[0];
+        let x = &args[1];
+        if y.data_type() != x.data_type() {
+            return exec_err!(
+                "div requires both operands to share a type; got {:?} vs {:?}",
+                y.data_type(),
+                x.data_type()
+            );
+        }
+        let out: ArrayRef = match y.data_type() {
+            DataType::Int8 => Arc::new(div_int::<Int8Type>(y, x)?.finish()),
+            DataType::Int16 => Arc::new(div_int::<Int16Type>(y, x)?.finish()),
+            DataType::Int32 => Arc::new(div_int::<Int32Type>(y, x)?.finish()),
+            DataType::Int64 => Arc::new(div_int::<Int64Type>(y, x)?.finish()),
+            other => return exec_err!("div only supports integer operands, got {other:?}"),
+        };
+        Ok(ColumnarValue::Array(out))
+    }
+}
+
+fn div_int<T>(y: &ArrayRef, x: &ArrayRef) -> Result<PrimitiveBuilder<T>>
+where
+    T: datafusion::arrow::datatypes::ArrowPrimitiveType,
+    T::Native: std::ops::Div<Output = T::Native> + PartialOrd + Default,
+{
+    let y = y.as_primitive::<T>();
+    let x = x.as_primitive::<T>();
+    let zero = T::Native::default();
+    let len = y.len().max(x.len());
+    let mut out = PrimitiveBuilder::<T>::with_capacity(len);
+    for i in 0..len {
+        let j = if y.len() == 1 { 0 } else { i };
+        let k = if x.len() == 1 { 0 } else { i };
+        if y.is_null(j) || x.is_null(k) || x.value(k) == zero {
+            // Postgres raises on integer div-by-zero; we return NULL because
+            // DataFusion cannot raise per-row errors.
+            out.append_null();
+        } else {
+            out.append_value(y.value(j) / x.value(k));
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::SessionContext;
+
+    async fn run_i64(ctx: &SessionContext, sql: &str) -> Option<i64> {
+        let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        let col = batches[0].column(0);
+        match col.data_type() {
+            DataType::Int8 => col.as_primitive::<Int8Type>().iter().next().unwrap().map(|v| v as i64),
+            DataType::Int16 => col.as_primitive::<Int16Type>().iter().next().unwrap().map(|v| v as i64),
+            DataType::Int32 => col.as_primitive::<Int32Type>().iter().next().unwrap().map(|v| v as i64),
+            DataType::Int64 => col.as_primitive::<Int64Type>().iter().next().unwrap(),
+            _ => panic!("unexpected type {:?}", col.data_type()),
+        }
+    }
+
+    #[tokio::test]
+    async fn div_postgres_examples() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_div_udf());
+
+        // From the Postgres docs:
+        //   div(9, 4)   = 2
+        //   div(-9, 4)  = -2
+        //   div(9, -4)  = -2
+        //   div(-9, -4) = 2
+        assert_eq!(run_i64(&ctx, "SELECT div(9, 4)").await, Some(2));
+        assert_eq!(run_i64(&ctx, "SELECT div(-9, 4)").await, Some(-2));
+        assert_eq!(run_i64(&ctx, "SELECT div(9, -4)").await, Some(-2));
+        assert_eq!(run_i64(&ctx, "SELECT div(-9, -4)").await, Some(2));
+    }
+
+    #[tokio::test]
+    async fn div_by_zero_returns_null() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_div_udf());
+        assert_eq!(run_i64(&ctx, "SELECT div(9, 0)").await, None);
+    }
+}

--- a/datafusion-pg-functions/src/numeric/div.rs
+++ b/datafusion-pg-functions/src/numeric/div.rs
@@ -10,11 +10,9 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
 use datafusion::arrow::array::Array;
-use datafusion::arrow::datatypes::{
-    DataType, Int16Type, Int32Type, Int64Type, Int8Type,
-};
+use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
+use datafusion::arrow::datatypes::{DataType, Int8Type, Int16Type, Int32Type, Int64Type};
 use datafusion::common::{Result, exec_err};
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, TypeSignature,
@@ -131,9 +129,24 @@ mod tests {
         let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
         let col = batches[0].column(0);
         match col.data_type() {
-            DataType::Int8 => col.as_primitive::<Int8Type>().iter().next().unwrap().map(|v| v as i64),
-            DataType::Int16 => col.as_primitive::<Int16Type>().iter().next().unwrap().map(|v| v as i64),
-            DataType::Int32 => col.as_primitive::<Int32Type>().iter().next().unwrap().map(|v| v as i64),
+            DataType::Int8 => col
+                .as_primitive::<Int8Type>()
+                .iter()
+                .next()
+                .unwrap()
+                .map(|v| v as i64),
+            DataType::Int16 => col
+                .as_primitive::<Int16Type>()
+                .iter()
+                .next()
+                .unwrap()
+                .map(|v| v as i64),
+            DataType::Int32 => col
+                .as_primitive::<Int32Type>()
+                .iter()
+                .next()
+                .unwrap()
+                .map(|v| v as i64),
             DataType::Int64 => col.as_primitive::<Int64Type>().iter().next().unwrap(),
             _ => panic!("unexpected type {:?}", col.data_type()),
         }

--- a/datafusion-pg-functions/src/numeric/mod_op.rs
+++ b/datafusion-pg-functions/src/numeric/mod_op.rs
@@ -19,12 +19,10 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{
-    ArrayRef, AsArray, PrimitiveBuilder,
-};
 use datafusion::arrow::array::Array;
+use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
 use datafusion::arrow::datatypes::{
-    DataType, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
+    DataType, Float32Type, Float64Type, Int8Type, Int16Type, Int32Type, Int64Type,
 };
 use datafusion::common::{Result, exec_err};
 use datafusion::logical_expr::{
@@ -107,16 +105,14 @@ impl ScalarUDFImpl for ModUDF {
             DataType::Int16 => Arc::new(mod_int::<Int16Type>(y, x)?.finish()),
             DataType::Int32 => Arc::new(mod_int::<Int32Type>(y, x)?.finish()),
             DataType::Int64 => Arc::new(mod_int::<Int64Type>(y, x)?.finish()),
-            DataType::Float32 => Arc::new(mod_float::<Float32Type, _>(y, x, |a, b| {
-                a - b * (a / b).trunc()
-            })?.finish()),
-            DataType::Float64 => Arc::new(mod_float::<Float64Type, _>(y, x, |a, b| {
-                a - b * (a / b).trunc()
-            })?.finish()),
+            DataType::Float32 => Arc::new(
+                mod_float::<Float32Type, _>(y, x, |a, b| a - b * (a / b).trunc())?.finish(),
+            ),
+            DataType::Float64 => Arc::new(
+                mod_float::<Float64Type, _>(y, x, |a, b| a - b * (a / b).trunc())?.finish(),
+            ),
             other => {
-                return exec_err!(
-                    "mod only supports integer/float operands, got {other:?}"
-                );
+                return exec_err!("mod only supports integer/float operands, got {other:?}");
             }
         };
         Ok(ColumnarValue::Array(out))
@@ -182,9 +178,24 @@ mod tests {
         let col = batches[0].column(0);
         use datafusion::arrow::array::Array;
         match col.data_type() {
-            DataType::Int8 => col.as_primitive::<Int8Type>().iter().next().unwrap().map(|v| v as i64),
-            DataType::Int16 => col.as_primitive::<Int16Type>().iter().next().unwrap().map(|v| v as i64),
-            DataType::Int32 => col.as_primitive::<Int32Type>().iter().next().unwrap().map(|v| v as i64),
+            DataType::Int8 => col
+                .as_primitive::<Int8Type>()
+                .iter()
+                .next()
+                .unwrap()
+                .map(|v| v as i64),
+            DataType::Int16 => col
+                .as_primitive::<Int16Type>()
+                .iter()
+                .next()
+                .unwrap()
+                .map(|v| v as i64),
+            DataType::Int32 => col
+                .as_primitive::<Int32Type>()
+                .iter()
+                .next()
+                .unwrap()
+                .map(|v| v as i64),
             DataType::Int64 => col.as_primitive::<Int64Type>().iter().next().unwrap(),
             _ => panic!("unexpected integer type {:?}", col.data_type()),
         }
@@ -192,7 +203,12 @@ mod tests {
 
     async fn run_f64(ctx: &SessionContext, sql: &str) -> Option<f64> {
         let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
-        batches[0].column(0).as_primitive::<Float64Type>().iter().next().unwrap()
+        batches[0]
+            .column(0)
+            .as_primitive::<Float64Type>()
+            .iter()
+            .next()
+            .unwrap()
     }
 
     #[tokio::test]

--- a/datafusion-pg-functions/src/numeric/mod_op.rs
+++ b/datafusion-pg-functions/src/numeric/mod_op.rs
@@ -214,7 +214,7 @@ mod tests {
     #[tokio::test]
     async fn mod_matches_postgres_examples() {
         let ctx = SessionContext::new();
-        ctx.register_udf(create_mod_udf().into());
+        ctx.register_udf(create_mod_udf());
 
         // From the Postgres docs:
         //   mod(9, 4)   = 1
@@ -230,7 +230,7 @@ mod tests {
     #[tokio::test]
     async fn mod_float_uses_trunc_quotient() {
         let ctx = SessionContext::new();
-        ctx.register_udf(create_mod_udf().into());
+        ctx.register_udf(create_mod_udf());
 
         // mod(7.5, 2.5) = 7.5 - 2.5 * trunc(7.5 / 2.5) = 7.5 - 2.5 * 3 = 0
         let got = run_f64(&ctx, "SELECT mod(7.5, 2.5)").await.unwrap();
@@ -248,7 +248,7 @@ mod tests {
     #[tokio::test]
     async fn mod_by_zero_returns_null() {
         let ctx = SessionContext::new();
-        ctx.register_udf(create_mod_udf().into());
+        ctx.register_udf(create_mod_udf());
         assert_eq!(run_i64(&ctx, "SELECT mod(9, 0)").await, None);
     }
 }

--- a/datafusion-pg-functions/src/numeric/mod_op.rs
+++ b/datafusion-pg-functions/src/numeric/mod_op.rs
@@ -1,0 +1,238 @@
+//! PostgreSQL `mod(y, x)` — the modulus function.
+//!
+//! DataFusion ships the `%` operator but not the function form `mod(y, x)`,
+//! so queries written against Postgres (which documents both forms) fail to
+//! resolve. This UDF produces the same result as `y % x` for integer inputs
+//! and follows Postgres semantics for the floating-point case
+//! (`mod(y, x) = y - x * trunc(y / x)`).
+//!
+//! # Postgres semantics
+//!
+//! Per the [PostgreSQL manual](https://www.postgresql.org/docs/current/functions-math.html):
+//!
+//! > `mod(y, x)` → remainder of `y / x`
+//!
+//! The result has the same sign as the dividend `y`, matching the SQL
+//! standard and Rust's built-in `%` operator for both integer and
+//! floating-point operands. Division by zero yields `NULL` (Postgres raises an
+//! error; we return NULL because DataFusion does not propagate error rows).
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    ArrayRef, AsArray, PrimitiveBuilder,
+};
+use datafusion::arrow::array::Array;
+use datafusion::arrow::datatypes::{
+    DataType, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
+};
+use datafusion::common::{Result, exec_err};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, TypeSignature,
+    Volatility,
+};
+
+/// Create the PostgreSQL `mod(y, x)` UDF.
+pub fn create_mod_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(ModUDF::default())
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ModUDF {
+    signature: Signature,
+}
+
+impl Default for ModUDF {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ModUDF {
+    pub fn new() -> Self {
+        use DataType::*;
+        // Postgres `mod` accepts integer (i8/i16/i32/i64) and floating-point
+        // (f32/f64) operands. Both arguments must share a type.
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Exact(vec![Int8, Int8]),
+                    TypeSignature::Exact(vec![Int16, Int16]),
+                    TypeSignature::Exact(vec![Int32, Int32]),
+                    TypeSignature::Exact(vec![Int64, Int64]),
+                    TypeSignature::Exact(vec![Float32, Float32]),
+                    TypeSignature::Exact(vec![Float64, Float64]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for ModUDF {
+    fn name(&self) -> &str {
+        "mod"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.len() != 2 || arg_types[0] != arg_types[1] {
+            return exec_err!(
+                "mod requires two arguments of the same type, got {:?}",
+                arg_types
+            );
+        }
+        Ok(arg_types[0].clone())
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        if args.len() != 2 {
+            return exec_err!("mod requires exactly 2 arguments, got {}", args.len());
+        }
+        let y = &args[0];
+        let x = &args[1];
+        if y.data_type() != x.data_type() {
+            return exec_err!(
+                "mod requires both operands to share a type; got y={:?}, x={:?}",
+                y.data_type(),
+                x.data_type()
+            );
+        }
+        let out: ArrayRef = match y.data_type() {
+            DataType::Int8 => Arc::new(mod_int::<Int8Type>(y, x)?.finish()),
+            DataType::Int16 => Arc::new(mod_int::<Int16Type>(y, x)?.finish()),
+            DataType::Int32 => Arc::new(mod_int::<Int32Type>(y, x)?.finish()),
+            DataType::Int64 => Arc::new(mod_int::<Int64Type>(y, x)?.finish()),
+            DataType::Float32 => Arc::new(mod_float::<Float32Type, _>(y, x, |a, b| {
+                a - b * (a / b).trunc()
+            })?.finish()),
+            DataType::Float64 => Arc::new(mod_float::<Float64Type, _>(y, x, |a, b| {
+                a - b * (a / b).trunc()
+            })?.finish()),
+            other => {
+                return exec_err!(
+                    "mod only supports integer/float operands, got {other:?}"
+                );
+            }
+        };
+        Ok(ColumnarValue::Array(out))
+    }
+}
+
+/// Elementwise integer modulus following Postgres semantics. Both arrays must
+/// be the same primitive type; either may be a length-1 broadcast scalar.
+fn mod_int<T>(y: &ArrayRef, x: &ArrayRef) -> Result<PrimitiveBuilder<T>>
+where
+    T: datafusion::arrow::datatypes::ArrowPrimitiveType,
+    T::Native: std::ops::Rem<Output = T::Native> + PartialOrd + Default,
+{
+    let y = y.as_primitive::<T>();
+    let x = x.as_primitive::<T>();
+    let zero = T::Native::default();
+    let len = y.len().max(x.len());
+    let mut out = PrimitiveBuilder::<T>::with_capacity(len);
+    for i in 0..len {
+        let j = if y.len() == 1 { 0 } else { i };
+        let k = if x.len() == 1 { 0 } else { i };
+        if y.is_null(j) || x.is_null(k) || x.value(k) == zero {
+            // Postgres raises an error on integer mod-by-zero; we return NULL
+            // because DataFusion cannot raise per-row errors.
+            out.append_null();
+        } else {
+            out.append_value(y.value(j) % x.value(k));
+        }
+    }
+    Ok(out)
+}
+
+/// Elementwise floating-point modulus. The closure lets us share the boilerplate
+/// between f32 and f64 with the only difference being the arithmetic.
+fn mod_float<T, F>(y: &ArrayRef, x: &ArrayRef, op: F) -> Result<PrimitiveBuilder<T>>
+where
+    T: datafusion::arrow::datatypes::ArrowPrimitiveType,
+    F: Fn(T::Native, T::Native) -> T::Native,
+{
+    let y = y.as_primitive::<T>();
+    let x = x.as_primitive::<T>();
+    let len = y.len().max(x.len());
+    let mut out = PrimitiveBuilder::<T>::with_capacity(len);
+    for i in 0..len {
+        let j = if y.len() == 1 { 0 } else { i };
+        let k = if x.len() == 1 { 0 } else { i };
+        if y.is_null(j) || x.is_null(k) {
+            out.append_null();
+        } else {
+            out.append_value(op(y.value(j), x.value(k)));
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::SessionContext;
+
+    async fn run_i64(ctx: &SessionContext, sql: &str) -> Option<i64> {
+        let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        let col = batches[0].column(0);
+        use datafusion::arrow::array::Array;
+        match col.data_type() {
+            DataType::Int8 => col.as_primitive::<Int8Type>().iter().next().unwrap().map(|v| v as i64),
+            DataType::Int16 => col.as_primitive::<Int16Type>().iter().next().unwrap().map(|v| v as i64),
+            DataType::Int32 => col.as_primitive::<Int32Type>().iter().next().unwrap().map(|v| v as i64),
+            DataType::Int64 => col.as_primitive::<Int64Type>().iter().next().unwrap(),
+            _ => panic!("unexpected integer type {:?}", col.data_type()),
+        }
+    }
+
+    async fn run_f64(ctx: &SessionContext, sql: &str) -> Option<f64> {
+        let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        batches[0].column(0).as_primitive::<Float64Type>().iter().next().unwrap()
+    }
+
+    #[tokio::test]
+    async fn mod_matches_postgres_examples() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_mod_udf().into());
+
+        // From the Postgres docs:
+        //   mod(9, 4)   = 1
+        //   mod(-9, 4)  = -1
+        //   mod(9, -4)  = 1
+        //   mod(-9, -4) = -1
+        assert_eq!(run_i64(&ctx, "SELECT mod(9, 4)").await, Some(1));
+        assert_eq!(run_i64(&ctx, "SELECT mod(-9, 4)").await, Some(-1));
+        assert_eq!(run_i64(&ctx, "SELECT mod(9, -4)").await, Some(1));
+        assert_eq!(run_i64(&ctx, "SELECT mod(-9, -4)").await, Some(-1));
+    }
+
+    #[tokio::test]
+    async fn mod_float_uses_trunc_quotient() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_mod_udf().into());
+
+        // mod(7.5, 2.5) = 7.5 - 2.5 * trunc(7.5 / 2.5) = 7.5 - 2.5 * 3 = 0
+        let got = run_f64(&ctx, "SELECT mod(7.5, 2.5)").await.unwrap();
+        assert!(got.abs() < 1e-12);
+
+        // Sign follows dividend.
+        let got = run_f64(&ctx, "SELECT mod(-7.5, 2.5)").await.unwrap();
+        assert!(got.abs() < 1e-12);
+
+        // mod(10.5, 3.0) = 10.5 - 3.0 * trunc(10.5 / 3.0) = 10.5 - 9.0 = 1.5
+        let got = run_f64(&ctx, "SELECT mod(10.5, 3.0)").await.unwrap();
+        assert!((got - 1.5).abs() < 1e-12);
+    }
+
+    #[tokio::test]
+    async fn mod_by_zero_returns_null() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_mod_udf().into());
+        assert_eq!(run_i64(&ctx, "SELECT mod(9, 0)").await, None);
+    }
+}

--- a/datafusion-pg-functions/src/numeric/random_normal.rs
+++ b/datafusion-pg-functions/src/numeric/random_normal.rs
@@ -22,10 +22,8 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{
-    ArrayRef, AsArray, Float64Builder,
-};
 use datafusion::arrow::array::Array;
+use datafusion::arrow::array::{ArrayRef, AsArray, Float64Builder};
 use datafusion::arrow::datatypes::{DataType, Float64Type};
 use datafusion::common::{Result, exec_err};
 use datafusion::logical_expr::{
@@ -167,9 +165,7 @@ mod tests {
         // are not just returning 0 (the probability of all 100 being within
         // 0.001 of 0 is essentially zero).
         assert!(
-            vals.iter()
-                .filter_map(|v| *v)
-                .any(|v| v.abs() > 0.001),
+            vals.iter().filter_map(|v| *v).any(|v| v.abs() > 0.001),
             "samples suspiciously close to zero"
         );
     }
@@ -201,6 +197,9 @@ mod tests {
             .unwrap()
             .collect()
             .await;
-        assert!(res.is_err(), "negative stddev should be rejected at execution");
+        assert!(
+            res.is_err(),
+            "negative stddev should be rejected at execution"
+        );
     }
 }

--- a/datafusion-pg-functions/src/numeric/random_normal.rs
+++ b/datafusion-pg-functions/src/numeric/random_normal.rs
@@ -1,0 +1,206 @@
+//! PostgreSQL `random_normal(mean, stddev)` — normal-distributed random variate.
+//!
+//! Per the [PostgreSQL manual](https://www.postgresql.org/docs/current/functions-math.html#FUNCTIONS-MATH-RANDOM-TABLE):
+//!
+//! > `random_normal([mean, stddev])` → double precision
+//! >
+//! > Returns a random value from the normal distribution with the given
+//! > `mean` (default 0.0) and `stddev` (default 1.0).
+//!
+//! The implementation uses the Box–Muller transform on top of `rand::random`,
+//! matching Postgres's behavior for default arguments. Unlike the radian
+//! trigonometric UDFs this function is **volatile** (each call yields a fresh
+//! random value).
+//!
+//! # Argument handling
+//!
+//! DataFusion UDFs do not currently model optional-with-default arguments
+//! directly, so we accept both the zero-arg form (`random_normal()`) and the
+//! explicit form (`random_normal(mean, stddev)`). The `mean`-only and
+//! `stddev`-only forms are not supported; require callers to pass both or
+//! neither.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    ArrayRef, AsArray, Float64Builder,
+};
+use datafusion::arrow::array::Array;
+use datafusion::arrow::datatypes::{DataType, Float64Type};
+use datafusion::common::{Result, exec_err};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use rand::{Rng, rng};
+
+/// Create the PostgreSQL `random_normal()` UDF.
+pub fn create_random_normal_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(RandomNormalUDF::default())
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct RandomNormalUDF {
+    signature: Signature,
+}
+
+impl Default for RandomNormalUDF {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RandomNormalUDF {
+    pub fn new() -> Self {
+        // Accept either `random_normal()` (zero args, defaults),
+        // `random_normal(mean, stddev)`, or any-arg variadic form.
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    datafusion::logical_expr::TypeSignature::Nullary,
+                    datafusion::logical_expr::TypeSignature::Exact(vec![
+                        DataType::Float64,
+                        DataType::Float64,
+                    ]),
+                    datafusion::logical_expr::TypeSignature::VariadicAny,
+                ],
+                Volatility::Volatile,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for RandomNormalUDF {
+    fn name(&self) -> &str {
+        "random_normal"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Float64)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let num_rows = args.number_rows;
+        let arrays = ColumnarValue::values_to_arrays(&args.args)?;
+        let (mean, stddev): (f64, f64) = match arrays.len() {
+            0 => (0.0, 1.0),
+            2 => {
+                let m = extract_scalar_f64(&arrays[0])?.unwrap_or(0.0);
+                let s = extract_scalar_f64(&arrays[1])?.unwrap_or(1.0);
+                if s < 0.0 {
+                    return exec_err!("stddev must be non-negative, got {s}");
+                }
+                (m, s)
+            }
+            n => return exec_err!("random_normal expects 0 or 2 args, got {n}"),
+        };
+
+        // Result length is the batch size from the surrounding context. This
+        // matches DataFusion's own `random()` UDF, which uses `args.number_rows`
+        // so that `SELECT random() FROM generate_series(1, 100)` returns 100
+        // distinct samples rather than a single scalar.
+        let len = num_rows.max(1);
+        let mut out = Float64Builder::with_capacity(len);
+        for _ in 0..len {
+            out.append_value(mean + stddev * box_muller());
+        }
+        Ok(ColumnarValue::Array(Arc::new(out.finish())))
+    }
+}
+
+/// Pull the first row of `arr` as `Option<f64>`. Used to extract the scalar
+/// `mean`/`stddev` arguments.
+fn extract_scalar_f64(arr: &ArrayRef) -> Result<Option<f64>> {
+    let a = arr.as_primitive::<Float64Type>();
+    if a.len() == 1 && !a.is_null(0) {
+        Ok(Some(a.value(0)))
+    } else if a.is_empty() || a.is_null(0) {
+        Ok(None)
+    } else {
+        Ok(Some(a.value(0)))
+    }
+}
+
+/// Standard Box–Muller transform: produces a single N(0, 1) sample.
+fn box_muller() -> f64 {
+    let mut rng = rng();
+    // Two independent uniforms in (0, 1]; rejection-sample u1 to avoid log(0).
+    let u1: f64 = loop {
+        let v = rng.random::<f64>();
+        if v > f64::MIN_POSITIVE {
+            break v;
+        }
+    };
+    let u2: f64 = rng.random::<f64>();
+    let r = (-2.0 * u1.ln()).sqrt();
+    let theta = 2.0 * std::f64::consts::PI * u2;
+    // Postgres uses a single sample per call; we discard the second variate.
+    r * theta.cos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::SessionContext;
+
+    async fn run_f64_list(ctx: &SessionContext, sql: &str) -> Vec<Option<f64>> {
+        let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        batches[0]
+            .column(0)
+            .as_primitive::<Float64Type>()
+            .iter()
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn default_args_returns_finite_values() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_random_normal_udf());
+
+        let vals = run_f64_list(&ctx, "SELECT random_normal() FROM generate_series(1, 100)").await;
+        assert_eq!(vals.len(), 100);
+        assert!(vals.iter().all(|v| v.is_some()));
+        // Sanity: at least one value should be far enough from 0 to confirm we
+        // are not just returning 0 (the probability of all 100 being within
+        // 0.001 of 0 is essentially zero).
+        assert!(
+            vals.iter()
+                .filter_map(|v| *v)
+                .any(|v| v.abs() > 0.001),
+            "samples suspiciously close to zero"
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_mean_stddev_shifts_distribution() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_random_normal_udf());
+
+        let vals = run_f64_list(
+            &ctx,
+            "SELECT random_normal(100.0, 0.5) FROM generate_series(1, 1000)",
+        )
+        .await;
+        let mean: f64 = vals.iter().filter_map(|v| *v).sum::<f64>() / vals.len() as f64;
+        // Loose bounds: with N=1000 from N(100, 0.5), the sample mean is
+        // within ~0.1 of 100 with overwhelming probability.
+        assert!((mean - 100.0).abs() < 0.1, "got mean = {mean}");
+    }
+
+    #[tokio::test]
+    async fn negative_stddev_errors() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_random_normal_udf());
+
+        let res = ctx
+            .sql("SELECT random_normal(0.0, -1.0)")
+            .await
+            .unwrap()
+            .collect()
+            .await;
+        assert!(res.is_err(), "negative stddev should be rejected at execution");
+    }
+}

--- a/datafusion-pg-functions/src/numeric/special.rs
+++ b/datafusion-pg-functions/src/numeric/special.rs
@@ -1,0 +1,204 @@
+//! PostgreSQL `erf`, `erfc`, `gamma`, `lgamma` — special functions.
+//!
+//! These four functions live in PostgreSQL's "Mathematical Functions" table
+//! but DataFusion does not ship them. They are all scalar, take one float
+//! argument, and return one float.
+//!
+//! # Implementation
+//!
+//! We use [`libm`] for the underlying numeric routines so the crate links
+//! against `libc` on Unix platforms (where these are direct `erf`/`erfc`/
+//! `lgamma`/`tgamma` symbols) and gets pure-Rust implementations elsewhere.
+//!
+//! | PG name  | libm function     | Notes                                   |
+//! |----------|-------------------|-----------------------------------------|
+//! | `erf(x)`   | `erf(f64)`        | error function                          |
+//! | `erfc(x)`  | `erfc(f64)`       | `1.0 - erf(x)` (computed directly)      |
+//! | `gamma(x)` | `tgamma(f64)`     | true gamma function                     |
+//! | `lgamma(x)`| `lgamma(f64)`     | natural log of `|gamma(x)|`             |
+//!
+//! Postgres's `gamma(0)` returns `Infinity` and `gamma(-integer)` returns
+//! `NaN` or raises an error depending on platform; we match libm's behavior.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
+use datafusion::arrow::array::Array;
+use datafusion::arrow::datatypes::{DataType, Float32Type, Float64Type};
+use datafusion::common::{Result, exec_err};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+
+/// Build a one-argument UDF that applies a pure `f64 -> f64` op elementwise,
+/// returning the same float type as its input.
+macro_rules! special_unary_udf {
+    (
+        $(#[$meta:meta])*
+        struct $struct_name:ident;
+        name = $sql_name:literal;
+        op = $f64_impl:expr;
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, PartialEq, Eq, Hash)]
+        pub struct $struct_name {
+            signature: Signature,
+        }
+
+        impl Default for $struct_name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl $struct_name {
+            pub fn new() -> Self {
+                Self {
+                    signature: Signature::uniform(
+                        1,
+                        vec![DataType::Float64, DataType::Float32],
+                        Volatility::Immutable,
+                    ),
+                }
+            }
+        }
+
+        impl ScalarUDFImpl for $struct_name {
+            fn name(&self) -> &str {
+                $sql_name
+            }
+
+            fn signature(&self) -> &Signature {
+                &self.signature
+            }
+
+            fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+                match arg_types[0] {
+                    DataType::Float32 => Ok(DataType::Float32),
+                    _ => Ok(DataType::Float64),
+                }
+            }
+
+            fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+                let args = ColumnarValue::values_to_arrays(&args.args)?;
+                if args.len() != 1 {
+                    return exec_err!("{} expects exactly 1 argument, got {}", $sql_name, args.len());
+                }
+                let op: fn(f64) -> f64 = $f64_impl;
+                let out: ArrayRef = match args[0].data_type() {
+                    DataType::Float64 => {
+                        let a = args[0].as_primitive::<Float64Type>();
+                        let mut b = PrimitiveBuilder::<Float64Type>::with_capacity(a.len());
+                        for i in 0..a.len() {
+                            if a.is_null(i) {
+                                b.append_null();
+                            } else {
+                                b.append_value(op(a.value(i)));
+                            }
+                        }
+                        Arc::new(b.finish())
+                    }
+                    DataType::Float32 => {
+                        let a = args[0].as_primitive::<Float32Type>();
+                        let mut b = PrimitiveBuilder::<Float32Type>::with_capacity(a.len());
+                        for i in 0..a.len() {
+                            if a.is_null(i) {
+                                b.append_null();
+                            } else {
+                                b.append_value(op(a.value(i) as f64) as f32);
+                            }
+                        }
+                        Arc::new(b.finish())
+                    }
+                    other => return exec_err!("{} requires float input, got {other:?}", $sql_name),
+                };
+                Ok(ColumnarValue::Array(out))
+            }
+        }
+    };
+}
+
+special_unary_udf! {
+    /// PostgreSQL `erf(x)` — Gauss error function.
+    struct ErfUDF;
+    name = "erf";
+    op = |x: f64| libm::erf(x);
+}
+
+special_unary_udf! {
+    /// PostgreSQL `erfc(x)` — complementary error function `1 - erf(x)`.
+    struct ErfcUDF;
+    name = "erfc";
+    op = |x: f64| libm::erfc(x);
+}
+
+special_unary_udf! {
+    /// PostgreSQL `gamma(x)` — true gamma function.
+    struct GammaUDF;
+    name = "gamma";
+    op = |x: f64| libm::tgamma(x);
+}
+
+special_unary_udf! {
+    /// PostgreSQL `lgamma(x)` — natural log of `|gamma(x)|`.
+    struct LgammaUDF;
+    name = "lgamma";
+    op = |x: f64| libm::lgamma_r(x).0;
+}
+
+pub fn create_erf_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(ErfUDF::default())
+}
+pub fn create_erfc_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(ErfcUDF::default())
+}
+pub fn create_gamma_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(GammaUDF::default())
+}
+pub fn create_lgamma_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(LgammaUDF::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::SessionContext;
+
+    async fn run_f64(ctx: &SessionContext, sql: &str) -> Option<f64> {
+        let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        batches[0].column(0).as_primitive::<Float64Type>().iter().next().unwrap()
+    }
+
+    fn ctx_with_all() -> SessionContext {
+        let ctx = SessionContext::new();
+        for udf in [
+            create_erf_udf(),
+            create_erfc_udf(),
+            create_gamma_udf(),
+            create_lgamma_udf(),
+        ] {
+            ctx.register_udf(udf);
+        }
+        ctx
+    }
+
+    #[tokio::test]
+    async fn known_values() {
+        let ctx = ctx_with_all();
+
+        // erf(0) = 0, erf(inf) = 1
+        assert!(run_f64(&ctx, "SELECT erf(0)").await.unwrap().abs() < 1e-12);
+        // erfc(x) = 1 - erf(x); erfc(0) = 1
+        assert!((run_f64(&ctx, "SELECT erfc(0)").await.unwrap() - 1.0).abs() < 1e-12);
+        // gamma(n) = (n-1)! for positive integers; gamma(5) = 4! = 24
+        assert!((run_f64(&ctx, "SELECT gamma(5)").await.unwrap() - 24.0).abs() < 1e-9);
+        // lgamma(5) = ln(24) ≈ 3.178
+        assert!((run_f64(&ctx, "SELECT lgamma(5)").await.unwrap() - 24.0_f64.ln()).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn null_propagates() {
+        let ctx = ctx_with_all();
+        assert_eq!(run_f64(&ctx, "SELECT erf(CAST(NULL AS DOUBLE))").await, None);
+    }
+}

--- a/datafusion-pg-functions/src/numeric/special.rs
+++ b/datafusion-pg-functions/src/numeric/special.rs
@@ -22,8 +22,8 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
 use datafusion::arrow::array::Array;
+use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
 use datafusion::arrow::datatypes::{DataType, Float32Type, Float64Type};
 use datafusion::common::{Result, exec_err};
 use datafusion::logical_expr::{
@@ -166,7 +166,12 @@ mod tests {
 
     async fn run_f64(ctx: &SessionContext, sql: &str) -> Option<f64> {
         let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
-        batches[0].column(0).as_primitive::<Float64Type>().iter().next().unwrap()
+        batches[0]
+            .column(0)
+            .as_primitive::<Float64Type>()
+            .iter()
+            .next()
+            .unwrap()
     }
 
     fn ctx_with_all() -> SessionContext {
@@ -199,6 +204,9 @@ mod tests {
     #[tokio::test]
     async fn null_propagates() {
         let ctx = ctx_with_all();
-        assert_eq!(run_f64(&ctx, "SELECT erf(CAST(NULL AS DOUBLE))").await, None);
+        assert_eq!(
+            run_f64(&ctx, "SELECT erf(CAST(NULL AS DOUBLE))").await,
+            None
+        );
     }
 }

--- a/datafusion-pg-functions/src/numeric/width_bucket.rs
+++ b/datafusion-pg-functions/src/numeric/width_bucket.rs
@@ -20,7 +20,7 @@ use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
 
 use datafusion::arrow::array::Array;
 use datafusion::arrow::datatypes::{
-    DataType, Field, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
+    DataType, Field, Float32Type, Float64Type, Int8Type, Int16Type, Int32Type, Int64Type,
 };
 use datafusion::common::{Result, exec_err};
 use datafusion::logical_expr::{
@@ -144,9 +144,11 @@ fn equal_width_form(args: &[ArrayRef]) -> Result<ColumnarValue> {
 
     let mut out: PrimitiveBuilder<Int32Type> = PrimitiveBuilder::with_capacity(operand.len());
     for i in 0..operand.len() {
-        let (Some(op), Some(lo), Some(hi)) =
-            (scalar_f64(operand, i), scalar_f64(low, 0), scalar_f64(high, 0))
-        else {
+        let (Some(op), Some(lo), Some(hi)) = (
+            scalar_f64(operand, i),
+            scalar_f64(low, 0),
+            scalar_f64(high, 0),
+        ) else {
             out.append_null();
             continue;
         };
@@ -243,7 +245,12 @@ mod tests {
 
     async fn run_i32(ctx: &SessionContext, sql: &str) -> Option<i32> {
         let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
-        batches[0].column(0).as_primitive::<Int32Type>().iter().next().unwrap()
+        batches[0]
+            .column(0)
+            .as_primitive::<Int32Type>()
+            .iter()
+            .next()
+            .unwrap()
     }
 
     #[tokio::test]

--- a/datafusion-pg-functions/src/numeric/width_bucket.rs
+++ b/datafusion-pg-functions/src/numeric/width_bucket.rs
@@ -1,0 +1,308 @@
+//! PostgreSQL `width_bucket(operand, low, high, count)` and
+//! `width_bucket(operand, thresholds)` — histogram bucket assignment.
+//!
+//! Per the [PostgreSQL manual](https://www.postgresql.org/docs/current/functions-math.html):
+//!
+//! - `width_bucket(operand, low, high, count)` returns an integer indicating
+//!   which of `count` equal-width buckets `operand` would fall into, with
+//!   buckets numbered from 1. `operand` < `low` returns 0; `operand` >= `high`
+//!   returns `count + 1`. `low`, `high`, and `count` must be positive numbers
+//!   and `count > 0`.
+//! - `width_bucket(operand, thresholds)` returns the index of the first
+//!   threshold `operand` is less than, plus 1; if `operand` is below the
+//!   lowest threshold it returns 0. `thresholds` must be sorted ascending.
+//!
+//! Both forms accept any numeric type. DataFusion does not ship either form.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, AsArray, PrimitiveBuilder};
+
+use datafusion::arrow::array::Array;
+use datafusion::arrow::datatypes::{
+    DataType, Field, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
+};
+use datafusion::common::{Result, exec_err};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, TypeSignature,
+    Volatility,
+};
+
+/// Create the PostgreSQL `width_bucket` UDF (supports both forms).
+pub fn create_width_bucket_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(WidthBucketUDF::default())
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct WidthBucketUDF {
+    signature: Signature,
+}
+
+impl Default for WidthBucketUDF {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WidthBucketUDF {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    // 4-arg equal-width form: (operand, low, high, count)
+                    TypeSignature::Exact(vec![
+                        DataType::Float64,
+                        DataType::Float64,
+                        DataType::Float64,
+                        DataType::Int32,
+                    ]),
+                    TypeSignature::Exact(vec![
+                        DataType::Float64,
+                        DataType::Float64,
+                        DataType::Float64,
+                        DataType::Int64,
+                    ]),
+                    TypeSignature::Exact(vec![
+                        DataType::Float32,
+                        DataType::Float32,
+                        DataType::Float32,
+                        DataType::Int32,
+                    ]),
+                    TypeSignature::Exact(vec![
+                        DataType::Float32,
+                        DataType::Float32,
+                        DataType::Float32,
+                        DataType::Int64,
+                    ]),
+                    // 2-arg sorted-thresholds form: (operand, thresholds[])
+                    TypeSignature::Exact(vec![
+                        DataType::Float64,
+                        DataType::List(Arc::new(Field::new_list_field(DataType::Float64, true))),
+                    ]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for WidthBucketUDF {
+    fn name(&self) -> &str {
+        "width_bucket"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Int32)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let arrays = ColumnarValue::values_to_arrays(&args.args)?;
+        match arrays.len() {
+            4 => equal_width_form(&arrays),
+            2 => thresholds_form(&arrays),
+            n => exec_err!("width_bucket expects 2 or 4 arguments, got {n}"),
+        }
+    }
+}
+
+/// `width_bucket(operand, low, high, count)` — equal-width form.
+fn equal_width_form(args: &[ArrayRef]) -> Result<ColumnarValue> {
+    let operand = &args[0];
+    let low = &args[1];
+    let high = &args[2];
+    let count = &args[3];
+
+    if operand.data_type() != low.data_type() || operand.data_type() != high.data_type() {
+        return exec_err!(
+            "width_bucket requires operand/low/high to share a type; got {:?}/{:?}/{:?}",
+            operand.data_type(),
+            low.data_type(),
+            high.data_type()
+        );
+    }
+
+    let counts: Option<i64> = match count.data_type() {
+        DataType::Int32 => count
+            .as_primitive::<Int32Type>()
+            .iter()
+            .next()
+            .flatten()
+            .map(|v| v as i64),
+        DataType::Int64 => count.as_primitive::<Int64Type>().iter().next().flatten(),
+        other => return exec_err!("width_bucket count must be int4/int8, got {other:?}"),
+    };
+    let Some(count) = counts else {
+        return exec_err!("width_bucket count must be a positive integer");
+    };
+    if count <= 0 {
+        return exec_err!("width_bucket count must be a positive integer");
+    }
+
+    let mut out: PrimitiveBuilder<Int32Type> = PrimitiveBuilder::with_capacity(operand.len());
+    for i in 0..operand.len() {
+        let (Some(op), Some(lo), Some(hi)) =
+            (scalar_f64(operand, i), scalar_f64(low, 0), scalar_f64(high, 0))
+        else {
+            out.append_null();
+            continue;
+        };
+        if lo >= hi {
+            return exec_err!("width_bucket requires low < high, got low={lo}, high={hi}");
+        }
+        let bucket = equal_width_bucket_f64(op, lo, hi, count);
+        out.append_value(bucket as i32);
+    }
+    Ok(ColumnarValue::Array(Arc::new(out.finish())))
+}
+
+fn equal_width_bucket_f64(op: f64, low: f64, high: f64, count: i64) -> i64 {
+    // Postgres semantics: operand < low -> 0; operand >= high -> count+1;
+    // otherwise 1 + floor(count * (op - low) / (high - low)).
+    if op.is_nan() {
+        // Postgres treats NaN the same as "below low" (returns 0).
+        return 0;
+    }
+    if op < low {
+        0
+    } else if op >= high {
+        count + 1
+    } else {
+        let step = (high - low) / count as f64;
+        let b = ((op - low) / step).floor() as i64 + 1;
+        // Clamp in case of float drift just at the boundary.
+        b.clamp(1, count)
+    }
+}
+
+/// `width_bucket(operand, thresholds)` — sorted-array form.
+fn thresholds_form(args: &[ArrayRef]) -> Result<ColumnarValue> {
+    let operand = &args[0];
+    let thresholds = &args[1];
+
+    let Some(thresholds_list) = as_f64_list(thresholds) else {
+        return exec_err!(
+            "width_bucket thresholds must be a sorted list of f64, got {:?}",
+            thresholds.data_type()
+        );
+    };
+
+    let mut out: PrimitiveBuilder<Int32Type> = PrimitiveBuilder::with_capacity(operand.len());
+    for i in 0..operand.len() {
+        let Some(op) = scalar_f64(operand, i) else {
+            out.append_null();
+            continue;
+        };
+        // Postgres: returns the bucket number = (index of first threshold that
+        // op <) + 0 if op is below the first threshold. Equivalently, number
+        // of thresholds op >=, clamped to [0, len].
+        if op.is_nan() {
+            out.append_value(0);
+            continue;
+        }
+        let bucket = thresholds_list.iter().filter(|&&t| op >= t).count();
+        out.append_value(bucket as i32);
+    }
+    Ok(ColumnarValue::Array(Arc::new(out.finish())))
+}
+
+/// Read row `i` of `arr` as `Option<f64>`. Only meaningful for primitive
+/// numeric arrays; non-numeric types return an error upstream.
+fn scalar_f64(arr: &ArrayRef, i: usize) -> Option<f64> {
+    if arr.is_null(i) {
+        return None;
+    }
+    match arr.data_type() {
+        DataType::Float64 => Some(arr.as_primitive::<Float64Type>().value(i)),
+        DataType::Float32 => Some(arr.as_primitive::<Float32Type>().value(i) as f64),
+        DataType::Int64 => Some(arr.as_primitive::<Int64Type>().value(i) as f64),
+        DataType::Int32 => Some(arr.as_primitive::<Int32Type>().value(i) as f64),
+        DataType::Int16 => Some(arr.as_primitive::<Int16Type>().value(i) as f64),
+        DataType::Int8 => Some(arr.as_primitive::<Int8Type>().value(i) as f64),
+        _ => None,
+    }
+}
+
+fn as_f64_list(arr: &ArrayRef) -> Option<Vec<f64>> {
+    let list = arr.as_list::<i32>();
+    if list.len() != 1 || list.is_null(0) {
+        return None;
+    }
+    let row = list.value(0);
+    let f = row.as_primitive::<Float64Type>();
+    Some(f.iter().map(|v| v.unwrap_or(f64::NAN)).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::SessionContext;
+
+    async fn run_i32(ctx: &SessionContext, sql: &str) -> Option<i32> {
+        let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        batches[0].column(0).as_primitive::<Int32Type>().iter().next().unwrap()
+    }
+
+    #[tokio::test]
+    async fn equal_width_postgres_examples() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_width_bucket_udf());
+
+        // From the Postgres docs:
+        //   width_bucket(5.35, 0.024, 10.06, 5) = 3
+        //   width_bucket(-0.4, 0.024, 10.06, 5) = 0   (below low)
+        //   width_bucket(11.0, 0.024, 10.06, 5) = 6   (above high)
+        assert_eq!(
+            run_i32(&ctx, "SELECT width_bucket(5.35, 0.024, 10.06, 5)").await,
+            Some(3)
+        );
+        assert_eq!(
+            run_i32(&ctx, "SELECT width_bucket(-0.4, 0.024, 10.06, 5)").await,
+            Some(0)
+        );
+        assert_eq!(
+            run_i32(&ctx, "SELECT width_bucket(11.0, 0.024, 10.06, 5)").await,
+            Some(6)
+        );
+    }
+
+    #[tokio::test]
+    async fn thresholds_form() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_width_bucket_udf());
+
+        // thresholds = [10, 20, 30] (sorted ascending).
+        //   25 >= [10, 20], not >= 30 -> 2
+        //   5  >= none -> 0
+        //   30 >= all three -> 3
+        assert_eq!(
+            run_i32(&ctx, "SELECT width_bucket(25, ARRAY[10.0, 20.0, 30.0])").await,
+            Some(2)
+        );
+        assert_eq!(
+            run_i32(&ctx, "SELECT width_bucket(5, ARRAY[10.0, 20.0, 30.0])").await,
+            Some(0)
+        );
+        assert_eq!(
+            run_i32(&ctx, "SELECT width_bucket(30, ARRAY[10.0, 20.0, 30.0])").await,
+            Some(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn null_operand_returns_null() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(create_width_bucket_udf());
+        assert_eq!(
+            run_i32(
+                &ctx,
+                "SELECT width_bucket(CAST(NULL AS DOUBLE), 0.0, 10.0, 5)"
+            )
+            .await,
+            None
+        );
+    }
+}

--- a/datafusion-pg-functions/src/range.rs
+++ b/datafusion-pg-functions/src/range.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/row.rs
+++ b/datafusion-pg-functions/src/row.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/sequence.rs
+++ b/datafusion-pg-functions/src/sequence.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/string.rs
+++ b/datafusion-pg-functions/src/string.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/system.rs
+++ b/datafusion-pg-functions/src/system.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/text_search.rs
+++ b/datafusion-pg-functions/src/text_search.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/uuid.rs
+++ b/datafusion-pg-functions/src/uuid.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/src/xml.rs
+++ b/datafusion-pg-functions/src/xml.rs
@@ -10,7 +10,7 @@ use datafusion::logical_expr::ScalarUDF;
 /// `registry`.
 ///
 /// Returns the number of UDFs that were registered.
-pub fn register(_registry: &dyn FunctionRegistry) -> usize {
+pub fn register(_registry: &mut dyn FunctionRegistry) -> usize {
     let _udfs: Vec<ScalarUDF> = vec![];
     // registry.register_udf(...);
     0

--- a/datafusion-pg-functions/tests/sqllogictest.rs
+++ b/datafusion-pg-functions/tests/sqllogictest.rs
@@ -156,15 +156,17 @@ async fn run_slt_files() {
         .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("slt"))
         .collect();
     entries.sort();
-    assert!(!entries.is_empty(), "no .slt files found in {}", dir.display());
+    assert!(
+        !entries.is_empty(),
+        "no .slt files found in {}",
+        dir.display()
+    );
 
     // Optional filter via env var SLT_FILTER=substring to run only matching files.
     let selected: Vec<PathBuf> = match std::env::var("SLT_FILTER") {
         Ok(stem) => entries
             .iter()
-            .filter(|p| {
-                p.to_string_lossy().contains(&stem)
-            })
+            .filter(|p| p.to_string_lossy().contains(&stem))
             .cloned()
             .collect(),
         Err(_) => entries,

--- a/datafusion-pg-functions/tests/sqllogictest.rs
+++ b/datafusion-pg-functions/tests/sqllogictest.rs
@@ -1,0 +1,185 @@
+//! Sqllogictest harness for `datafusion-pg-functions`.
+//!
+//! Each `.slt` file under `tests/sqllogictest/` is run against a fresh
+//! [`SessionContext`] that has had [`register_all`](datafusion_pg_functions::register_all)
+//! applied. The harness implements [`sqllogictest::AsyncDB`] by delegating SQL
+//! execution to DataFusion and converting the resulting arrow `RecordBatch`es
+//! into the row-of-strings format sqllogictest compares against.
+//!
+//! Add new test cases to `.slt` files; no Rust changes needed unless a new
+//! column type shows up that the engine doesn't know how to render.
+//!
+//! Run with:
+//!   cargo test -p datafusion-pg-functions --test sqllogictest
+//!
+//! Or filter to a single category:
+//!   cargo test -p datafusion-pg-functions --test sqllogictest -- math
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use datafusion::arrow::array::{Array, AsArray, RecordBatch};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::util::display::ArrayFormatter;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::prelude::SessionContext;
+use datafusion_pg_functions::register_all;
+use sqllogictest::{AsyncDB, DBOutput, DefaultColumnType};
+
+/// Thin wrapper around a `SessionContext` registered with every UDF this
+/// crate ships under the categories enabled by Cargo features.
+struct PgFunctionsDb {
+    ctx: SessionContext,
+}
+
+impl PgFunctionsDb {
+    fn new() -> Self {
+        let mut ctx = SessionContext::new();
+        let n = register_all(&mut ctx);
+        eprintln!("[sqllogictest] registered {n} UDFs");
+        Self { ctx }
+    }
+}
+
+#[async_trait]
+impl AsyncDB for PgFunctionsDb {
+    type Error = DataFusionError;
+    type ColumnType = DefaultColumnType;
+
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<DefaultColumnType>> {
+        let df = self.ctx.sql(sql).await?;
+        let schema = df.schema().clone();
+        let batches = df.collect().await?;
+
+        // DDL/DML: no result columns -> treat as statement completion.
+        if schema.fields().is_empty() {
+            return Ok(DBOutput::StatementComplete(0));
+        }
+
+        let types = schema
+            .fields()
+            .iter()
+            .map(|f| arrow_to_slt_type(f.data_type()))
+            .collect();
+
+        let mut rows: Vec<Vec<String>> = Vec::new();
+        for batch in batches {
+            for row in row_strings(&batch)? {
+                rows.push(row);
+            }
+        }
+
+        Ok(DBOutput::Rows { types, rows })
+    }
+
+    async fn shutdown(&mut self) {}
+}
+
+/// Map an arrow `DataType` to the closest sqllogictest column type.
+/// Anything we don't model (lists, structs, binary, ...) falls back to
+/// `Any` (`?`), which disables type checking on that column.
+fn arrow_to_slt_type(dt: &DataType) -> DefaultColumnType {
+    use DefaultColumnType::*;
+    match dt {
+        DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64 => Integer,
+        DataType::Float16 | DataType::Float32 | DataType::Float64 => FloatingPoint,
+        DataType::Boolean => Text, // sqllogictest renders booleans as t/f strings
+        _ => Any,
+    }
+}
+
+/// Render a `RecordBatch` as a `Vec<Vec<String>>` (one inner vec per row).
+/// NULL cells become `"NULL"`. Floats use Rust's `{:?}` debug format so that
+/// integer-valued floats keep their trailing `.0` (e.g. `1.0`, not `1`).
+fn row_strings(batch: &RecordBatch) -> Result<Vec<Vec<String>>> {
+    use datafusion::arrow::datatypes::*;
+
+    let formatters: Vec<ArrayFormatter> = batch
+        .columns()
+        .iter()
+        .map(|c| ArrayFormatter::try_new(c.as_ref(), &Default::default()))
+        .collect::<std::result::Result<_, _>>()?;
+
+    let mut out = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let cells: Vec<String> = (0..batch.num_columns())
+            .map(|col| {
+                let arr = batch.column(col);
+                if arr.is_null(row) {
+                    return "NULL".to_string();
+                }
+                let raw = formatters[col].value(row).to_string();
+                // Float debug formatting gives us trailing .0 on integer values,
+                // which matches the .slt expected-value convention.
+                match arr.data_type() {
+                    DataType::Float32 => {
+                        // value() already came from the primitive; re-format from the
+                        // array directly to ensure {:?} semantics.
+                        let v = arr.as_primitive::<Float32Type>().value(row);
+                        format!("{v:?}")
+                    }
+                    DataType::Float64 => {
+                        let v = arr.as_primitive::<Float64Type>().value(row);
+                        format!("{v:?}")
+                    }
+                    _ => raw,
+                }
+            })
+            .collect();
+        out.push(cells);
+    }
+    Ok(out)
+}
+
+fn slt_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/sqllogictest")
+}
+
+#[tokio::test]
+async fn run_slt_files() {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
+        .is_test(true)
+        .try_init();
+
+    let dir = slt_dir();
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()))
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("slt"))
+        .collect();
+    entries.sort();
+    assert!(!entries.is_empty(), "no .slt files found in {}", dir.display());
+
+    // Optional filter via env var SLT_FILTER=substring to run only matching files.
+    let selected: Vec<PathBuf> = match std::env::var("SLT_FILTER") {
+        Ok(stem) => entries
+            .iter()
+            .filter(|p| {
+                p.to_string_lossy().contains(&stem)
+            })
+            .cloned()
+            .collect(),
+        Err(_) => entries,
+    };
+    assert!(!selected.is_empty(), "SLT_FILTER matched no files",);
+
+    let mut failures: Vec<String> = Vec::new();
+    for path in selected {
+        eprintln!("[sqllogictest] running {}", path.display());
+        let mut runner = sqllogictest::Runner::new(|| async { Ok(PgFunctionsDb::new()) });
+        if let Err(e) = runner.run_file_async(&path).await {
+            failures.push(format!("{}:\n{e}", path.display()));
+        }
+    }
+    if !failures.is_empty() {
+        panic!("slt failures:\n\n{}\n", failures.join("\n\n"));
+    }
+}

--- a/datafusion-pg-functions/tests/sqllogictest/math.slt
+++ b/datafusion-pg-functions/tests/sqllogictest/math.slt
@@ -1,0 +1,415 @@
+# Integration tests for the PostgreSQL math functions implemented in
+# `datafusion-pg-functions/src/numeric/`.
+#
+# Each section exercises one UDF via the full SQL -> plan -> execute path
+# against a `SessionContext` that has had `register_all` applied.
+#
+# Conventions:
+#   * Float values are formatted with Rust's `{:?}` (round-trippable, always
+#     shows a decimal point). Expected values below were captured from the
+#     current implementation; update them if the underlying libm/Rust math
+#     behavior shifts.
+#   * `round(...)` is used where the math has irreducible float error
+#     (e.g. `sind(30)` is `0.49999999999999994`) and the intent of the test
+#     is to verify the function semantics, not the precise bits.
+#   * NULL inputs must propagate to NULL.
+#   * Where Postgres raises an error (integer div/mod by zero) we return NULL
+#     instead -- DataFusion cannot raise per-row errors.
+
+# ============================================================================
+# ceiling(x) -- alias of ceil
+# ============================================================================
+
+query R
+SELECT ceiling(2.4)
+----
+3.0
+
+query R
+SELECT ceiling(-2.4)
+----
+-2.0
+
+query R
+SELECT ceiling(0.0)
+----
+0.0
+
+query R
+SELECT ceiling(CAST(NULL AS DOUBLE))
+----
+NULL
+
+# ceiling must agree with ceil on every input.
+query R
+SELECT ceiling(7.7) - ceil(7.7)
+----
+0.0
+
+# ============================================================================
+# sign(x) -- alias of signum
+# ============================================================================
+
+query R
+SELECT sign(-7)
+----
+-1.0
+
+query R
+SELECT sign(0)
+----
+0.0
+
+query R
+SELECT sign(3.5)
+----
+1.0
+
+query R
+SELECT sign(-3.5)
+----
+-1.0
+
+query R
+SELECT sign(CAST(NULL AS INT))
+----
+NULL
+
+# ============================================================================
+# mod(y, x) -- modulus function
+# ============================================================================
+
+# Postgres doc examples (integer).
+query I
+SELECT mod(9, 4)
+----
+1
+
+query I
+SELECT mod(-9, 4)
+----
+-1
+
+query I
+SELECT mod(9, -4)
+----
+1
+
+query I
+SELECT mod(-9, -4)
+----
+-1
+
+# Integer type variants: i8 / i16 / i32 / i64 all work.
+query I
+SELECT mod(CAST(9 AS TINYINT), CAST(4 AS TINYINT))
+----
+1
+
+query I
+SELECT mod(CAST(9 AS SMALLINT), CAST(4 AS SMALLINT))
+----
+1
+
+query I
+SELECT mod(CAST(9 AS BIGINT), CAST(4 AS BIGINT))
+----
+1
+
+# Float variant uses Postgres `y - x * trunc(y / x)` semantics.
+query R
+SELECT mod(7.5, 2.5)
+----
+0.0
+
+query R
+SELECT mod(10.5, 3.0)
+----
+1.5
+
+# Division by zero returns NULL (Postgres raises; DataFusion cannot per-row).
+query I
+SELECT mod(9, 0)
+----
+NULL
+
+# NULL propagates.
+query I
+SELECT mod(CAST(NULL AS INT), 4)
+----
+NULL
+
+query I
+SELECT mod(9, CAST(NULL AS INT))
+----
+NULL
+
+# ============================================================================
+# div(y, x) -- integer quotient
+# ============================================================================
+
+query I
+SELECT div(9, 4)
+----
+2
+
+query I
+SELECT div(-9, 4)
+----
+-2
+
+query I
+SELECT div(9, -4)
+----
+-2
+
+query I
+SELECT div(-9, -4)
+----
+2
+
+query I
+SELECT div(CAST(9 AS TINYINT), CAST(4 AS TINYINT))
+----
+2
+
+query I
+SELECT div(CAST(9 AS BIGINT), CAST(4 AS BIGINT))
+----
+2
+
+query I
+SELECT div(9, 0)
+----
+NULL
+
+query I
+SELECT div(CAST(NULL AS INT), 4)
+----
+NULL
+
+# ============================================================================
+# Degree-variant trigonometric functions
+# ============================================================================
+
+# ---- sind ----
+query R
+SELECT sind(0)
+----
+0.0
+
+# sind(30) is mathematically 0.5 but irreducibly 0.49999999999999994 in f64.
+query R
+SELECT sind(30)
+----
+0.49999999999999994
+
+query R
+SELECT sind(90)
+----
+1.0
+
+# ---- cosd ----
+query R
+SELECT cosd(0)
+----
+1.0
+
+query R
+SELECT cosd(60)
+----
+0.5000000000000001
+
+# cosd(90) is essentially 0 but with float error; round for a clean expected.
+query R
+SELECT round(cosd(90), 10)
+----
+0.0
+
+# ---- tand ----
+query R
+SELECT tand(45)
+----
+0.9999999999999999
+
+# ---- cotd ----
+query R
+SELECT cotd(45)
+----
+1.0000000000000002
+
+# ---- asind / acosd / atand / atan2d (inverse, results in degrees) ----
+query R
+SELECT asind(0.5)
+----
+30.000000000000004
+
+query R
+SELECT acosd(0.5)
+----
+60.00000000000001
+
+query R
+SELECT atand(1.0)
+----
+45.0
+
+query R
+SELECT atan2d(1, 1)
+----
+45.0
+
+# Round-trip identity: degrees(acosd(x)) ~= acos(x).
+query R
+SELECT round(asind(sind(30)), 10)
+----
+30.0
+
+# NULL propagation across all eight degree functions.
+query R
+SELECT sind(CAST(NULL AS DOUBLE))
+----
+NULL
+
+query R
+SELECT cosd(CAST(NULL AS DOUBLE))
+----
+NULL
+
+query R
+SELECT tand(CAST(NULL AS DOUBLE))
+----
+NULL
+
+query R
+SELECT cotd(CAST(NULL AS DOUBLE))
+----
+NULL
+
+query R
+SELECT asind(CAST(NULL AS DOUBLE))
+----
+NULL
+
+query R
+SELECT acosd(CAST(NULL AS DOUBLE))
+----
+NULL
+
+query R
+SELECT atand(CAST(NULL AS DOUBLE))
+----
+NULL
+
+query R
+SELECT atan2d(CAST(NULL AS DOUBLE), 1.0)
+----
+NULL
+
+# ============================================================================
+# width_bucket
+# ============================================================================
+
+# Postgres docs example (4-arg equal-width form).
+query I
+SELECT width_bucket(5.35, 0.024, 10.06, 5)
+----
+3
+
+# Operand below `low` -> bucket 0.
+query I
+SELECT width_bucket(-0.4, 0.024, 10.06, 5)
+----
+0
+
+# Operand >= `high` -> bucket count+1.
+query I
+SELECT width_bucket(11.0, 0.024, 10.06, 5)
+----
+6
+
+# 2-arg sorted-thresholds form.
+query I
+SELECT width_bucket(25, ARRAY[10.0, 20.0, 30.0])
+----
+2
+
+query I
+SELECT width_bucket(5, ARRAY[10.0, 20.0, 30.0])
+----
+0
+
+query I
+SELECT width_bucket(30, ARRAY[10.0, 20.0, 30.0])
+----
+3
+
+query I
+SELECT width_bucket(CAST(NULL AS DOUBLE), 0.0, 10.0, 5)
+----
+NULL
+
+# ============================================================================
+# random_normal -- non-deterministic, test statistical properties
+# ============================================================================
+
+# Default args (mean=0, stddev=1) must produce a finite f64.
+query R
+SELECT CASE WHEN random_normal() - random_normal() = random_normal() - random_normal()
+            THEN 1.0 ELSE 0.0 END IS NOT NULL
+----
+true
+
+# Explicit mean=100, stddev=0.5; with 10000 samples the sample mean should be
+# very close to 100. Loose bound (3 sigma) avoids flakiness.
+query R
+SELECT abs((SELECT avg(random_normal(100.0, 0.5)) FROM generate_series(1, 10000)) - 100.0) < 0.05
+----
+true
+
+# Negative stddev must be rejected (returns execution error -> NULL is not ok).
+# sqllogictest's `statement error` directive asserts that the SQL fails.
+statement error
+SELECT random_normal(0.0, -1.0)
+
+# ============================================================================
+# Special functions: erf, erfc, gamma, lgamma
+# ============================================================================
+
+query R
+SELECT erf(0)
+----
+0.0
+
+query R
+SELECT erfc(0)
+----
+1.0
+
+# gamma(n) = (n-1)!; gamma(5) = 4! = 24.
+query R
+SELECT gamma(5)
+----
+24.0
+
+# lgamma(5) = ln(24).
+query R
+SELECT round(lgamma(5) - ln(24.0), 10)
+----
+0.0
+
+# Complementary identity: erfc(x) = 1 - erf(x). Round because of float drift.
+query R
+SELECT round(erfc(0.5) - (1.0 - erf(0.5)), 10)
+----
+0.0
+
+query R
+SELECT erf(CAST(NULL AS DOUBLE))
+----
+NULL
+
+query R
+SELECT gamma(CAST(NULL AS DOUBLE))
+----
+NULL


### PR DESCRIPTION
Implements the first batch of PostgreSQL built-in functions in the new
`datafusion-pg-functions` crate, focused on the **mathematical functions**
category. See `datafusion-pg-functions/functions.md` for the full catalog
this draws from.

## What's new

**18 UDFs** in `datafusion-pg-functions/src/numeric/`:

| File | Functions | Notes |
|---|---|---|
| `aliases.rs` | `ceiling`, `sign` | Thin aliases via `ScalarUDF::with_aliases` → DF `ceil`/`signum` |
| `mod_op.rs` | `mod(y, x)` | DF only ships the `%` op; this exposes the function form. Floats use `y - x*trunc(y/x)`; mod-by-zero returns NULL |
| `degree_trig.rs` | `sind`, `cosd`, `tand`, `cotd`, `asind`, `acosd`, `atand`, `atan2d` | Macro-generated; thin wrappers around radian trig + unit conversion |
| `div.rs` | `div(y, x)` | Integer quotient; div-by-zero → NULL |
| `random_normal.rs` | `random_normal([mean, stddev])` | Box-Muller; uses `args.number_rows` so it returns one sample per row when called over a table |
| `width_bucket.rs` | `width_bucket` | Both 4-arg equal-width form and 2-arg sorted-array form |
| `special.rs` | `erf`, `erfc`, `gamma`, `lgamma` | Backed by `libm` |

## Supporting changes

- **`register()` signature** changed from `&dyn FunctionRegistry` to `&mut dyn FunctionRegistry` across all category modules — `FunctionRegistry::register_udf` takes `&mut self`, which we now actually exercise from `numeric::register`.
- **`functions.md`** updated: the 18 new functions flip from `🚧 P1/P2/P3` → `🔧`; `log10` corrected from `🚧` → `✅` (it was in DataFusion all along).
- Added `libm` and `rand = "0.9"` dependencies.

## Verification

- ✅ `cargo test -p datafusion-pg-functions` — 19 new unit tests, all passing
- ✅ `cargo clippy -p datafusion-pg-functions` — clean
- ✅ `cargo check --workspace` — entire workspace still builds

Tests cover Postgres-doc examples (`mod(9,4)=1`, `div(-9,4)=-2`,
`width_bucket(5.35, 0.024, 10.06, 5)=3`, `gamma(5)=24`), NULL propagation,
div/mod-by-zero, and a sanity check on `random_normal`'s distribution.

## What's deferred

Four P3 math entries are intentionally not in this PR:
- `min_scale`, `scale`, `trim_scale` — need Decimal128-specific work
- `setseed` — thread-safety concerns around mutating a global RNG

## Follow-ups

The catalog in `functions.md` identifies the next high-value targets:
string functions (17 P2 entries, many already ✅ in DF), then datetime
(22 P2 entries like `age`, `clock_timestamp`, `make_interval`).