### PR TITLE
fix(pg_catalog): deterministic, stable OIDs for pooled clients (#389, #390)

### DIFF
--- a/datafusion-pg-catalog/src/pg_catalog.rs
+++ b/datafusion-pg-catalog/src/pg_catalog.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
 
 use async_trait::async_trait;
 use datafusion::arrow::array::{
@@ -224,10 +223,10 @@ const PG_CATALOG_NAMESPACE_OID: u32 = 11;
 pub(crate) fn stable_oid(key: &OidCacheKey) -> u32 {
     // pg_catalog must keep its canonical fixed OID so the static rows that
     // reference namespace 11 line up with pg_namespace/pg_class.
-    if let OidCacheKey::Schema(_, schema) = key {
-        if schema == "pg_catalog" {
-            return PG_CATALOG_NAMESPACE_OID;
-        }
+    if let OidCacheKey::Schema(_, schema) = key
+        && schema == "pg_catalog"
+    {
+        return PG_CATALOG_NAMESPACE_OID;
     }
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -239,7 +238,6 @@ pub(crate) fn stable_oid(key: &OidCacheKey) -> u32 {
 #[derive(Debug)]
 pub struct PgCatalogSchemaProvider<C, P> {
     catalog_list: C,
-    oid_counter: Arc<AtomicU32>,
     oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>,
     static_tables: Arc<PgCatalogStaticTables>,
     context_provider: P,
@@ -273,7 +271,6 @@ impl<C: CatalogInfo, P: PgCatalogContextProvider> PgCatalogSchemaProvider<C, P> 
     ) -> Result<PgCatalogSchemaProvider<C, P>> {
         Ok(Self {
             catalog_list,
-            oid_counter: Arc::new(AtomicU32::new(16384)),
             oid_cache: Arc::new(RwLock::new(HashMap::new())),
             static_tables,
             context_provider,
@@ -411,7 +408,6 @@ impl<C: CatalogInfo, P: PgCatalogContextProvider> PgCatalogSchemaProvider<C, P> 
             PG_CATALOG_TABLE_PG_ATTRIBUTE => {
                 let table = Arc::new(pg_attribute::PgAttributeTable::new(
                     self.catalog_list.clone(),
-                    self.oid_counter.clone(),
                     self.oid_cache.clone(),
                 ));
                 Ok(Some(PgCatalogTable::Dynamic(table)))
@@ -419,7 +415,6 @@ impl<C: CatalogInfo, P: PgCatalogContextProvider> PgCatalogSchemaProvider<C, P> 
             PG_CATALOG_TABLE_PG_CLASS => {
                 let table = Arc::new(pg_class::PgClassTable::new(
                     self.catalog_list.clone(),
-                    self.oid_counter.clone(),
                     self.oid_cache.clone(),
                 ));
                 Ok(Some(PgCatalogTable::Dynamic(table)))
@@ -427,7 +422,6 @@ impl<C: CatalogInfo, P: PgCatalogContextProvider> PgCatalogSchemaProvider<C, P> 
             PG_CATALOG_TABLE_PG_DATABASE => {
                 let table = Arc::new(pg_database::PgDatabaseTable::new(
                     self.catalog_list.clone(),
-                    self.oid_counter.clone(),
                     self.oid_cache.clone(),
                 ));
                 Ok(Some(PgCatalogTable::Dynamic(table)))
@@ -435,7 +429,6 @@ impl<C: CatalogInfo, P: PgCatalogContextProvider> PgCatalogSchemaProvider<C, P> 
             PG_CATALOG_TABLE_PG_NAMESPACE => {
                 let table = Arc::new(pg_namespace::PgNamespaceTable::new(
                     self.catalog_list.clone(),
-                    self.oid_counter.clone(),
                     self.oid_cache.clone(),
                 ));
                 Ok(Some(PgCatalogTable::Dynamic(table)))

--- a/datafusion-pg-catalog/src/pg_catalog.rs
+++ b/datafusion-pg-catalog/src/pg_catalog.rs
@@ -198,6 +198,43 @@ pub(crate) enum OidCacheKey {
     Table(String, String, String),
 }
 
+/// First OID in the user (non-reserved) space. Static/system catalog objects
+/// use the real PostgreSQL OIDs below this.
+const FIRST_USER_OID: u32 = 16384;
+
+/// Fixed OID of the `pg_catalog` namespace in every PostgreSQL cluster
+/// (`PG_CATALOG_NAMESPACE`). The static catalog rows this crate ships
+/// (`pg_type.typnamespace`, `pg_proc.pronamespace`, …) all reference 11, so
+/// `pg_namespace`/`pg_class` must report the same or clients can't join a system
+/// object to its namespace (e.g. DBeaver resolving a column's type via pg_type).
+const PG_CATALOG_NAMESPACE_OID: u32 = 11;
+
+/// Deterministic OID for a catalog object, derived from its name-based cache
+/// key. PostgreSQL OIDs are stable, and pooled clients (DBeaver, etc.) resolve
+/// an OID on one connection and reference it on another; a per-connection
+/// counter produced different OIDs each connection, so cross-connection lookups
+/// (e.g. `pg_class WHERE relnamespace = <public oid>`) returned nothing. Hashing
+/// the key makes the same object resolve to the same OID on every connection,
+/// independent of iteration order or which catalog table is queried first.
+///
+/// `DefaultHasher` uses fixed keys (unlike `RandomState`), so the result is
+/// stable across processes. Mapped into `[FIRST_USER_OID, i32::MAX]` — a
+/// positive range (OIDs are carried as `int4`) that avoids the reserved/static
+/// catalog OIDs below `FIRST_USER_OID`.
+pub(crate) fn stable_oid(key: &OidCacheKey) -> u32 {
+    // pg_catalog must keep its canonical fixed OID so the static rows that
+    // reference namespace 11 line up with pg_namespace/pg_class.
+    if let OidCacheKey::Schema(_, schema) = key {
+        if schema == "pg_catalog" {
+            return PG_CATALOG_NAMESPACE_OID;
+        }
+    }
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    FIRST_USER_OID + (hasher.finish() as u32) % (i32::MAX as u32 - FIRST_USER_OID)
+}
+
 // Create custom schema provider for pg_catalog
 #[derive(Debug)]
 pub struct PgCatalogSchemaProvider<C, P> {

--- a/datafusion-pg-catalog/src/pg_catalog/pg_attribute.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_attribute.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use datafusion::arrow::array::{
     ArrayRef, BooleanArray, Int16Array, Int32Array, RecordBatch, StringArray,
@@ -22,16 +21,11 @@ use super::oid_field;
 pub(crate) struct PgAttributeTable<C> {
     schema: SchemaRef,
     catalog_list: C,
-    oid_counter: Arc<AtomicU32>,
     oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>,
 }
 
 impl<C: CatalogInfo> PgAttributeTable<C> {
-    pub(crate) fn new(
-        catalog_list: C,
-        oid_counter: Arc<AtomicU32>,
-        oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>,
-    ) -> Self {
+    pub(crate) fn new(catalog_list: C, oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>) -> Self {
         // Define the schema for pg_attribute
         // This matches PostgreSQL's pg_attribute table columns
         let schema = Arc::new(Schema::new(vec![
@@ -66,7 +60,6 @@ impl<C: CatalogInfo> PgAttributeTable<C> {
         Self {
             schema,
             catalog_list,
-            oid_counter,
             oid_cache,
         }
     }

--- a/datafusion-pg-catalog/src/pg_catalog/pg_attribute.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_attribute.rs
@@ -124,7 +124,7 @@ impl<C: CatalogInfo> PgAttributeTable<C> {
                             let table_oid = if let Some(oid) = oid_cache.get(&cache_key) {
                                 *oid
                             } else {
-                                this.oid_counter.fetch_add(1, Ordering::Relaxed)
+                                super::stable_oid(&cache_key)
                             };
                             swap_cache.insert(cache_key, table_oid);
 

--- a/datafusion-pg-catalog/src/pg_catalog/pg_class.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_class.rs
@@ -124,7 +124,7 @@ impl<C: CatalogInfo> PgClassTable<C> {
             let catalog_oid = if let Some(oid) = oid_cache.get(&cache_key) {
                 *oid
             } else {
-                this.oid_counter.fetch_add(1, Ordering::Relaxed)
+                super::stable_oid(&cache_key)
             };
             swap_cache.insert(cache_key, catalog_oid);
 
@@ -134,7 +134,7 @@ impl<C: CatalogInfo> PgClassTable<C> {
                     let schema_oid = if let Some(oid) = oid_cache.get(&cache_key) {
                         *oid
                     } else {
-                        this.oid_counter.fetch_add(1, Ordering::Relaxed)
+                        super::stable_oid(&cache_key)
                     };
                     swap_cache.insert(cache_key, schema_oid);
 
@@ -156,7 +156,7 @@ impl<C: CatalogInfo> PgClassTable<C> {
                             let table_oid = if let Some(oid) = oid_cache.get(&cache_key) {
                                 *oid
                             } else {
-                                this.oid_counter.fetch_add(1, Ordering::Relaxed)
+                                super::stable_oid(&cache_key)
                             };
                             swap_cache.insert(cache_key, table_oid);
 

--- a/datafusion-pg-catalog/src/pg_catalog/pg_class.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_class.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use datafusion::arrow::array::{
     ArrayRef, BooleanArray, Float64Array, Int16Array, Int32Array, RecordBatch, StringArray,
@@ -24,16 +23,11 @@ use super::OidCacheKey;
 pub(crate) struct PgClassTable<C> {
     schema: SchemaRef,
     catalog_list: C,
-    oid_counter: Arc<AtomicU32>,
     oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>,
 }
 
 impl<C: CatalogInfo> PgClassTable<C> {
-    pub(crate) fn new(
-        catalog_list: C,
-        oid_counter: Arc<AtomicU32>,
-        oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>,
-    ) -> Self {
+    pub(crate) fn new(catalog_list: C, oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>) -> Self {
         // Define the schema for pg_class
         // This matches key columns from PostgreSQL's pg_class
         let schema = Arc::new(Schema::new(vec![
@@ -73,7 +67,6 @@ impl<C: CatalogInfo> PgClassTable<C> {
         Self {
             schema,
             catalog_list,
-            oid_counter,
             oid_cache,
         }
     }

--- a/datafusion-pg-catalog/src/pg_catalog/pg_database.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_database.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use datafusion::arrow::array::{
     ArrayRef, BooleanArray, Int32Array, ListArray, RecordBatch, StringArray,
@@ -21,16 +20,11 @@ use super::OidCacheKey;
 pub(crate) struct PgDatabaseTable<C> {
     schema: SchemaRef,
     catalog_list: C,
-    oid_counter: Arc<AtomicU32>,
     oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>,
 }
 
 impl<C: CatalogInfo> PgDatabaseTable<C> {
-    pub(crate) fn new(
-        catalog_list: C,
-        oid_counter: Arc<AtomicU32>,
-        oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>,
-    ) -> Self {
+    pub(crate) fn new(catalog_list: C, oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>) -> Self {
         // Define the schema for pg_database
         // This matches PostgreSQL's pg_database table columns
         let schema = Arc::new(Schema::new(vec![
@@ -60,7 +54,6 @@ impl<C: CatalogInfo> PgDatabaseTable<C> {
         Self {
             schema,
             catalog_list,
-            oid_counter,
             oid_cache,
         }
     }

--- a/datafusion-pg-catalog/src/pg_catalog/pg_database.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_database.rs
@@ -97,7 +97,7 @@ impl<C: CatalogInfo> PgDatabaseTable<C> {
             let catalog_oid = if let Some(oid) = oid_cache.get(&cache_key) {
                 *oid
             } else {
-                this.oid_counter.fetch_add(1, Ordering::Relaxed)
+                super::stable_oid(&cache_key)
             };
             catalog_oid_cache.insert(cache_key, catalog_oid);
 
@@ -128,7 +128,7 @@ impl<C: CatalogInfo> PgDatabaseTable<C> {
             let catalog_oid = if let Some(oid) = oid_cache.get(&cache_key) {
                 *oid
             } else {
-                this.oid_counter.fetch_add(1, Ordering::Relaxed)
+                super::stable_oid(&cache_key)
             };
             catalog_oid_cache.insert(cache_key, catalog_oid);
 

--- a/datafusion-pg-catalog/src/pg_catalog/pg_namespace.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_namespace.rs
@@ -71,7 +71,7 @@ impl<C: CatalogInfo> PgNamespaceTable<C> {
                     let schema_oid = if let Some(oid) = oid_cache.get(&cache_key) {
                         *oid
                     } else {
-                        this.oid_counter.fetch_add(1, Ordering::Relaxed)
+                        super::stable_oid(&cache_key)
                     };
                     schema_oid_cache.insert(cache_key, schema_oid);
 

--- a/datafusion-pg-catalog/src/pg_catalog/pg_namespace.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_namespace.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use datafusion::arrow::array::{ArrayRef, Int32Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -21,16 +20,11 @@ use super::OidCacheKey;
 pub(crate) struct PgNamespaceTable<C> {
     schema: SchemaRef,
     catalog_list: C,
-    oid_counter: Arc<AtomicU32>,
     oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>,
 }
 
 impl<C: CatalogInfo> PgNamespaceTable<C> {
-    pub(crate) fn new(
-        catalog_list: C,
-        oid_counter: Arc<AtomicU32>,
-        oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>,
-    ) -> Self {
+    pub(crate) fn new(catalog_list: C, oid_cache: Arc<RwLock<HashMap<OidCacheKey, Oid>>>) -> Self {
         // Define the schema for pg_namespace
         // This matches the columns from PostgreSQL's pg_namespace
         let schema = Arc::new(Schema::new(vec![
@@ -44,7 +38,6 @@ impl<C: CatalogInfo> PgNamespaceTable<C> {
         Self {
             schema,
             catalog_list,
-            oid_counter,
             oid_cache,
         }
     }


### PR DESCRIPTION
## What

Makes `pg_catalog` OID assignment deterministic and stable, fixing two problems that break pooled PostgreSQL clients (e.g. DBeaver) against a datafusion-postgres server.

Closes #389 — OIDs unstable across connections.
Closes #390 — `pg_catalog` namespace should be the fixed OID 11.

## Problem

`PgCatalogSchemaProvider` assigns catalog/schema/table OIDs from a per-provider `AtomicU32` counter, incremented in iteration order. A typical pgwire server creates a fresh `SessionContext` + `setup_pg_catalog` per connection, so the same object gets a different OID on different connections. Pooled clients resolve an OID on one connection and reference it on another, so `pg_class WHERE relnamespace = <oid>` matches nothing and no tables are listed.

Separately, `pg_catalog` receives a generated OID, but the static catalog rows this crate ships reference the canonical `PG_CATALOG_NAMESPACE` OID **11** (`pg_type.typnamespace = 11`, `pg_proc.pronamespace = 11`, …). No namespace with OID 11 exists in `pg_namespace`, so joins from a system object to its namespace fail — e.g. DBeaver can't resolve any column's data type (every column shows as unknown).

## Fix

Add `stable_oid(&OidCacheKey)`: a deterministic hash (`DefaultHasher` — fixed keys, so stable across processes) of the object's `(catalog, schema, table)` name, mapped into the positive `int4` range `[16384, i32::MAX]`, with `pg_catalog` pinned to its fixed OID `11`. The seven counter sites in `pg_class`/`pg_namespace`/`pg_database`/`pg_attribute` now call `stable_oid` instead of `oid_counter.fetch_add`.

The same object now resolves to the same OID on every connection, independent of iteration order or which catalog table is queried first.

## Notes

- Left the now-unused `oid_counter` field/params in place to keep the diff minimal — happy to remove them (and the `Ordering` imports) if you'd prefer.
- Collision risk is negligible for realistic catalog sizes; can switch to a wider/interned scheme if desired.
- Verified against a live DBeaver session (tables and column types now resolve) plus unit coverage in a downstream consumer.
- Filed as #389 / #390; addressed together here since the fix is a single function — happy to split into two PRs if you'd rather review them separately.
