### PR TITLE
fix(pg_catalog): stop pg_attribute from evicting schema/catalog OIDs (#389)

### DIFF
--- a/datafusion-pg-catalog/src/pg_catalog.rs
+++ b/datafusion-pg-catalog/src/pg_catalog.rs
@@ -1595,6 +1595,135 @@ mod test {
         assert_eq!(typoutput, "textout");
     }
 
+    // --- OID stability regressions for #389 -------------------------------------
+    //
+    // The dynamic catalog tables (`pg_namespace`, `pg_class`, `pg_attribute`,
+    // `pg_database`) share one OID counter + cache, and each builder reconciles
+    // that cache against the live catalog. `pg_attribute` used to replace the
+    // whole cache with table-only keys (`*oid_cache = swap_cache`), which
+    // silently deleted every `Catalog`/`Schema` OID. The next `pg_namespace` /
+    // `pg_class` query then re-allocated the schema a *different* OID, so an
+    // OID a pooled client (DBeaver, JDBC) resolved earlier no longer matched —
+    // e.g. `pg_class WHERE relnamespace = <oid>` returned nothing.
+    //
+    // These tests pin the invariant: a schema's OID is stable across catalog
+    // queries, and `pg_class.relnamespace` joins back to the `pg_namespace.oid`
+    // a client resolved earlier.
+
+    /// A session with a single user table `datafusion.public.t` and pg_catalog
+    /// installed, matching how the server sets up a connection.
+    async fn ctx_with_user_table() -> SessionContext {
+        use crate::pg_catalog::context::EmptyContextProvider;
+        use datafusion::prelude::{SessionConfig, SessionContext};
+
+        let config = SessionConfig::new().with_default_catalog_and_schema("datafusion", "public");
+        let ctx = SessionContext::new_with_config(config);
+        ctx.sql("CREATE TABLE t (a INT, b TEXT)")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        setup_pg_catalog(&ctx, "datafusion", EmptyContextProvider).unwrap();
+        ctx
+    }
+
+    async fn collect(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+        ctx.sql(sql).await.unwrap().collect().await.unwrap()
+    }
+
+    /// First value of the first column of the first batch, as `int4`.
+    fn first_i32(batches: &[RecordBatch]) -> i32 {
+        use datafusion::arrow::array::Int32Array;
+        batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .value(0)
+    }
+
+    /// First value of the first column of the first batch, as `int8`
+    /// (DataFusion's `count(*)` type).
+    fn first_i64(batches: &[RecordBatch]) -> i64 {
+        use datafusion::arrow::array::Int64Array;
+        batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0)
+    }
+
+    #[tokio::test]
+    async fn schema_oid_is_stable_across_pg_attribute_query() {
+        // Regression for #389. `pg_attribute` must not evict schema OIDs from
+        // the shared cache; otherwise the same schema resolves to a different
+        // OID before/after a column-metadata query. A schema's OID must be
+        // stable across catalog-table queries.
+        let ctx = ctx_with_user_table().await;
+
+        let oid_before = first_i32(
+            &collect(
+                &ctx,
+                "SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public'",
+            )
+            .await,
+        );
+
+        // Force the (formerly) cache-evicting builder to run.
+        let _ = collect(&ctx, "SELECT count(*) FROM pg_catalog.pg_attribute").await;
+
+        let oid_after = first_i32(
+            &collect(
+                &ctx,
+                "SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public'",
+            )
+            .await,
+        );
+
+        assert_eq!(
+            oid_before, oid_after,
+            "OID of the 'public' schema must not change after querying pg_attribute"
+        );
+    }
+
+    #[tokio::test]
+    async fn pg_class_resolves_table_via_namespace_oid() {
+        // Regression for #389 — the concrete user-facing breakage. A client
+        // resolves a schema OID from pg_namespace, then filters pg_class by
+        // that OID (`WHERE relnamespace = <oid>`). After pg_attribute ran, the
+        // schema OID used to drift and the filter matched nothing, so no tables
+        // were listed (the symptom DBeaver users report).
+        let ctx = ctx_with_user_table().await;
+
+        let nsp_oid = first_i32(
+            &collect(
+                &ctx,
+                "SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public'",
+            )
+            .await,
+        );
+
+        let _ = collect(&ctx, "SELECT count(*) FROM pg_catalog.pg_attribute").await;
+
+        let n = first_i64(
+            &collect(
+                &ctx,
+                &format!(
+                    "SELECT count(*) FROM pg_catalog.pg_class \
+                     WHERE relnamespace = {nsp_oid} AND relname = 't'"
+                ),
+            )
+            .await,
+        );
+
+        assert!(
+            n >= 1,
+            "expected user table 't' to resolve via relnamespace = {nsp_oid}, got {n}"
+        );
+    }
+
     #[test]
     fn test_load_arrow_data() {
         let table = ArrowTable::from_ipc_data(

--- a/datafusion-pg-catalog/src/pg_catalog/pg_attribute.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_attribute.rs
@@ -102,9 +102,15 @@ impl<C: CatalogInfo> PgAttributeTable<C> {
         let mut attmissingvals: Vec<Option<String>> = Vec::new();
 
         let mut oid_cache = this.oid_cache.write().await;
-        // Every time when call pg_catalog we generate a new cache and drop the
-        // original one in case that schemas or tables were dropped.
-        let mut swap_cache = HashMap::new();
+        // Collect the table OIDs assigned this run into a local map, then
+        // reconcile the shared cache below. pg_attribute enumerates only
+        // tables, so it must NOT discard `Catalog`/`Schema` entries it didn't
+        // visit. The previous `*oid_cache = swap_cache` replaced the whole
+        // cache with table-only keys, silently deleting every schema/catalog
+        // OID; the next pg_namespace/pg_class query then re-allocated the
+        // schema a *different* OID, breaking OID-based joins (e.g. DBeaver's
+        // `pg_class WHERE relnamespace = <oid>`). See #389.
+        let mut table_oid_cache = HashMap::new();
 
         for catalog_name in this.catalog_list.catalog_names().await? {
             if let Some(schema_names) = this.catalog_list.schema_names(&catalog_name).await? {
@@ -126,7 +132,7 @@ impl<C: CatalogInfo> PgAttributeTable<C> {
                             } else {
                                 this.oid_counter.fetch_add(1, Ordering::Relaxed)
                             };
-                            swap_cache.insert(cache_key, table_oid);
+                            table_oid_cache.insert(cache_key, table_oid);
 
                             if let Some(table_schema) = this
                                 .catalog_list
@@ -174,7 +180,16 @@ impl<C: CatalogInfo> PgAttributeTable<C> {
             }
         }
 
-        *oid_cache = swap_cache;
+        // Reconcile: drop only stale `Table` entries (tables that no longer
+        // exist); leave `Catalog` and `Schema` entries untouched, then refresh
+        // the live table OIDs. This mirrors pg_namespace's surgical retain
+        // rather than clobbering keys this builder never enumerated.
+        oid_cache.retain(|key, _| match key {
+            OidCacheKey::Catalog(..) => true,
+            OidCacheKey::Schema(..) => true,
+            OidCacheKey::Table(..) => table_oid_cache.contains_key(key),
+        });
+        oid_cache.extend(table_oid_cache);
 
         // Create Arrow arrays from the collected data
         let arrays: Vec<ArrayRef> = vec![


### PR DESCRIPTION
## What

A surgical fix for the `pg_catalog` OID instability in #389: **stop `pg_attribute` from evicting `Catalog`/`Schema` OIDs out of the shared OID cache.** Plus two regression tests.

This is a narrower, more targeted alternative to #391 (which derives OIDs deterministically via hashing). Both fix the same symptom; this one keeps the existing counter + cache design and just removes the over-broad cache rewrite that caused the drift.

## Root cause

The dynamic catalog tables (`pg_namespace`, `pg_class`, `pg_attribute`, `pg_database`) share one OID counter + cache, and each builder reconciles that cache against the live catalog. `pg_attribute` reconciled by **wholesale-replacing** the cache:

```rust
let mut swap_cache = HashMap::new();
... swap_cache.insert(Table(..), oid) ...   // only Table keys ever inserted
*oid_cache = swap_cache;                     // cache becomes *exactly* the tables I visited
```

`pg_attribute` enumerates **only tables**, so `swap_cache` only ever held `Table` keys. The replacement therefore silently deleted every `Catalog`/`Schema` OID — not because those objects were gone, but because `pg_attribute` never looked at them. The next `pg_namespace`/`pg_class` query then hit a cache miss for the schema and re-allocated it a **different** OID via the counter. A pooled client (DBeaver, JDBC) that resolved a schema OID earlier — e.g. `pg_class WHERE relnamespace = <oid>` — now matched nothing, so no tables/columns were listed.

Reproduces within a **single shared `SessionContext`** (the deployment model of the shipped server, which shares one context across all connections):

```
pg_namespace.oid(public): 16384 -> 16457   (unstable, after a pg_attribute query)
pg_class rows joining on relnamespace=16384: 0
```

Key nuance: `pg_attribute` **does** preserve OIDs for the tables it visits (it reads `oid_cache.get` and carries the value into `swap_cache`). The bug is purely that its wholesale `*oid_cache = swap_cache` discards the keys it *doesn't* visit. It conflates "I didn't enumerate it" with "it doesn't exist."

## Fix

Reconcile surgically, the way `pg_namespace` already does — drop only stale `Table` entries, leave `Catalog`/`Schema` entries untouched, then refresh the live table OIDs:

```rust
oid_cache.retain(|key, _| match key {
    OidCacheKey::Catalog(..) => true,
    OidCacheKey::Schema(..) => true,
    OidCacheKey::Table(..) => table_oid_cache.contains_key(key),
});
oid_cache.extend(table_oid_cache);
```

The other three builders don't need changes:
- `pg_namespace` — already surgical (`retain` + `extend`).
- `pg_database` — already surgical (`retain` + `extend`).
- `pg_class` — wholesale-replaces, but its view is **complete** (catalog+schema+table), so replace == upsert + correct GC. No drift.

After the fix the schema OID is stable across a `pg_attribute` query and the join resolves:

```
pg_namespace.oid(public): 16384 -> 16384   (stable)
pg_class rows joining on relnamespace=16384: 1
```

## Tests

Two regression tests added (both fail on `master`, pass with this change):

- `schema_oid_is_stable_across_pg_attribute_query` — a schema's OID must not change after a column-metadata query.
- `pg_class_resolves_table_via_namespace_oid` — the DBeaver symptom: filtering `pg_class` by an earlier-resolved `relnamespace` must still resolve the table.

`cargo fmt --check`, `cargo clippy --all-features -- -D warnings`, the full `datafusion-pg-catalog` suite (48), and the `dbeaver`/`psql`/`pgcli`/`metabase` integration tests all pass.

## Scope

Addresses **#389 only.** #390 (`pg_catalog` must keep the fixed namespace OID 11 that the static catalog rows reference) is orthogonal and intentionally left untouched here. (A test for #390 lives on the separate test-only branch/PR #392.)

Closes #389.

## vs. #391

#391 replaces the counter entirely with deterministic `stable_oid(key) = hash(key)`. That is the more robust design (also survives process restarts and makes the cache redundant), but it's a larger change and, as written, leaves dead code that fails this repo's `-D warnings` gate (unused `Ordering` imports + unread `oid_counter` fields + a clippy `collapsible_if`). This PR is the minimal fix that removes the actual drift while preserving the existing design; either approach resolves the symptom.
