### PR TITLE
fix(pg_catalog): pin pg_catalog namespace to its canonical OID 11 (#390)

### DIFF
--- a/datafusion-pg-catalog/src/pg_catalog.rs
+++ b/datafusion-pg-catalog/src/pg_catalog.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use async_trait::async_trait;
 use datafusion::arrow::array::{
@@ -196,6 +196,61 @@ pub(crate) enum OidCacheKey {
     Schema(String, String),
     /// Table by schema and table name
     Table(String, String, String),
+}
+
+/// Canonical OID of the `pg_catalog` namespace in every PostgreSQL cluster
+/// (`PG_CATALOG_NAMESPACE`). The static catalog rows this crate ships
+/// (`pg_type.typnamespace`, `pg_proc.pronamespace`, … — see the
+/// `pg_catalog_arrow_exports` produced by `export_pg_catalog_arrow.sh`) all
+/// reference 11, so `pg_namespace`/`pg_class` must report the same OID or a
+/// client can't join a system object back to its namespace (e.g. DBeaver
+/// resolving a column's data type). See #390.
+const PG_CATALOG_NAMESPACE_OID: Oid = 11;
+
+/// Returns the fixed canonical OID for a catalog object, if it has one.
+///
+/// Some objects must keep a specific PostgreSQL-assigned OID so the static
+/// catalog rows this crate ships (`pg_catalog_arrow_exports`, produced by
+/// `export_pg_catalog_arrow.sh`) join back correctly. For example, the
+/// `pg_catalog` namespace must be OID 11 because `pg_type.typnamespace` /
+/// `pg_proc.pronamespace` reference 11. See #390.
+///
+/// Keyed by [`OidCacheKey`] so additional fixed OIDs (other namespaces,
+/// catalogs, tables, ...) can be added as new match arms. These OIDs sit below
+/// the user range (the dynamic counter starts at 16384), so they never collide
+/// with an OID handed out dynamically. Returns `None` for objects without a
+/// fixed OID, leaving them to the normal cache/counter path.
+pub(crate) fn fixed_oid(key: &OidCacheKey) -> Option<Oid> {
+    match key {
+        OidCacheKey::Schema(_, schema) if schema == "pg_catalog" => Some(PG_CATALOG_NAMESPACE_OID),
+        _ => None,
+    }
+}
+
+/// Resolve the OID for `key`, consulting each source in priority order:
+///
+/// 1. a fixed canonical OID ([`fixed_oid`]) if this object has one -- so
+///    well-known objects keep their PostgreSQL-assigned OIDs regardless of
+///    cache state or counter position;
+/// 2. the previously assigned OID in `oid_cache`, if present -- keeping OIDs
+///    stable across catalog queries;
+/// 3. otherwise a freshly allocated OID from `oid_counter`.
+///
+/// Routing every OID assignment through here guarantees [`fixed_oid`] is
+/// always consulted, including for catalogs and tables (future fixed OIDs for
+/// those kinds are just new match arms in [`fixed_oid`]).
+pub(crate) fn resolve_oid(
+    key: &OidCacheKey,
+    oid_cache: &HashMap<OidCacheKey, Oid>,
+    oid_counter: &AtomicU32,
+) -> Oid {
+    if let Some(oid) = fixed_oid(key) {
+        oid
+    } else if let Some(oid) = oid_cache.get(key) {
+        *oid
+    } else {
+        oid_counter.fetch_add(1, Ordering::Relaxed)
+    }
 }
 
 // Create custom schema provider for pg_catalog
@@ -1721,6 +1776,43 @@ mod test {
         assert!(
             n >= 1,
             "expected user table 't' to resolve via relnamespace = {nsp_oid}, got {n}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pg_catalog_namespace_keeps_fixed_oid_eleven() {
+        // Regression for #390. The static catalog rows this crate ships
+        // reference the canonical `pg_catalog` namespace OID 11 (e.g.
+        // `pg_type.typnamespace = 11`, `pg_proc.pronamespace = 11`). If
+        // `pg_namespace` assigns `pg_catalog` a generated OID instead, joins
+        // from a system object to its namespace fail -- e.g. DBeaver cannot
+        // resolve any column's data type and every column shows as unknown.
+        // `pg_catalog` must keep the fixed OID 11.
+        let ctx = ctx_with_user_table().await;
+
+        let oid = first_i32(
+            &collect(
+                &ctx,
+                "SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'pg_catalog'",
+            )
+            .await,
+        );
+        assert_eq!(oid, 11, "pg_catalog namespace must use the fixed OID 11");
+
+        // And the join a client performs: a built-in type -> its namespace.
+        let n = first_i64(
+            &collect(
+                &ctx,
+                "SELECT count(*) \
+                 FROM pg_catalog.pg_type t \
+                 JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace \
+                 WHERE t.typname = 'int4'",
+            )
+            .await,
+        );
+        assert_eq!(
+            n, 1,
+            "built-in type 'int4' must join to its pg_catalog namespace (oid 11)"
         );
     }
 

--- a/datafusion-pg-catalog/src/pg_catalog/pg_attribute.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_attribute.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::AtomicU32;
 
 use datafusion::arrow::array::{
     ArrayRef, BooleanArray, Int16Array, Int32Array, RecordBatch, StringArray,
@@ -15,8 +15,8 @@ use tokio::sync::RwLock;
 
 use crate::pg_catalog::catalog_info::CatalogInfo;
 
-use super::OidCacheKey;
 use super::oid_field;
+use super::{OidCacheKey, resolve_oid};
 
 #[derive(Debug, Clone)]
 pub(crate) struct PgAttributeTable<C> {
@@ -127,11 +127,7 @@ impl<C: CatalogInfo> PgAttributeTable<C> {
                                 schema_name.clone(),
                                 table_name.clone(),
                             );
-                            let table_oid = if let Some(oid) = oid_cache.get(&cache_key) {
-                                *oid
-                            } else {
-                                this.oid_counter.fetch_add(1, Ordering::Relaxed)
-                            };
+                            let table_oid = resolve_oid(&cache_key, &oid_cache, &this.oid_counter);
                             table_oid_cache.insert(cache_key, table_oid);
 
                             if let Some(table_schema) = this

--- a/datafusion-pg-catalog/src/pg_catalog/pg_class.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_class.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::AtomicU32;
 
 use datafusion::arrow::array::{
     ArrayRef, BooleanArray, Float64Array, Int16Array, Int32Array, RecordBatch, StringArray,
@@ -18,7 +18,7 @@ use tokio::sync::RwLock;
 
 use crate::pg_catalog::catalog_info::{CatalogInfo, table_type_to_string};
 
-use super::OidCacheKey;
+use super::{OidCacheKey, resolve_oid};
 
 #[derive(Debug, Clone)]
 pub(crate) struct PgClassTable<C> {
@@ -121,21 +121,13 @@ impl<C: CatalogInfo> PgClassTable<C> {
         // Iterate through all catalogs and schemas
         for catalog_name in this.catalog_list.catalog_names().await? {
             let cache_key = OidCacheKey::Catalog(catalog_name.clone());
-            let catalog_oid = if let Some(oid) = oid_cache.get(&cache_key) {
-                *oid
-            } else {
-                this.oid_counter.fetch_add(1, Ordering::Relaxed)
-            };
+            let catalog_oid = resolve_oid(&cache_key, &oid_cache, &this.oid_counter);
             swap_cache.insert(cache_key, catalog_oid);
 
             if let Some(schema_names) = this.catalog_list.schema_names(&catalog_name).await? {
                 for schema_name in schema_names {
                     let cache_key = OidCacheKey::Schema(catalog_name.clone(), schema_name.clone());
-                    let schema_oid = if let Some(oid) = oid_cache.get(&cache_key) {
-                        *oid
-                    } else {
-                        this.oid_counter.fetch_add(1, Ordering::Relaxed)
-                    };
+                    let schema_oid = resolve_oid(&cache_key, &oid_cache, &this.oid_counter);
                     swap_cache.insert(cache_key, schema_oid);
 
                     // Add an entry for the schema itself (as a namespace)
@@ -153,11 +145,7 @@ impl<C: CatalogInfo> PgClassTable<C> {
                                 schema_name.clone(),
                                 table_name.clone(),
                             );
-                            let table_oid = if let Some(oid) = oid_cache.get(&cache_key) {
-                                *oid
-                            } else {
-                                this.oid_counter.fetch_add(1, Ordering::Relaxed)
-                            };
+                            let table_oid = resolve_oid(&cache_key, &oid_cache, &this.oid_counter);
                             swap_cache.insert(cache_key, table_oid);
 
                             if let Some(table_schema) = this

--- a/datafusion-pg-catalog/src/pg_catalog/pg_database.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_database.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::AtomicU32;
 
 use datafusion::arrow::array::{
     ArrayRef, BooleanArray, Int32Array, ListArray, RecordBatch, StringArray,
@@ -15,7 +15,7 @@ use tokio::sync::RwLock;
 
 use crate::pg_catalog::catalog_info::CatalogInfo;
 
-use super::OidCacheKey;
+use super::{OidCacheKey, resolve_oid};
 
 #[derive(Debug, Clone)]
 pub(crate) struct PgDatabaseTable<C> {
@@ -94,11 +94,7 @@ impl<C: CatalogInfo> PgDatabaseTable<C> {
         // Add a record for each catalog (treating catalogs as "databases")
         for catalog_name in this.catalog_list.catalog_names().await? {
             let cache_key = OidCacheKey::Catalog(catalog_name.clone());
-            let catalog_oid = if let Some(oid) = oid_cache.get(&cache_key) {
-                *oid
-            } else {
-                this.oid_counter.fetch_add(1, Ordering::Relaxed)
-            };
+            let catalog_oid = resolve_oid(&cache_key, &oid_cache, &this.oid_counter);
             catalog_oid_cache.insert(cache_key, catalog_oid);
 
             oids.push(catalog_oid as i32);
@@ -125,11 +121,7 @@ impl<C: CatalogInfo> PgDatabaseTable<C> {
         let default_datname = "postgres".to_string();
         if !datnames.contains(&default_datname) {
             let cache_key = OidCacheKey::Catalog(default_datname.clone());
-            let catalog_oid = if let Some(oid) = oid_cache.get(&cache_key) {
-                *oid
-            } else {
-                this.oid_counter.fetch_add(1, Ordering::Relaxed)
-            };
+            let catalog_oid = resolve_oid(&cache_key, &oid_cache, &this.oid_counter);
             catalog_oid_cache.insert(cache_key, catalog_oid);
 
             oids.push(catalog_oid as i32);

--- a/datafusion-pg-catalog/src/pg_catalog/pg_namespace.rs
+++ b/datafusion-pg-catalog/src/pg_catalog/pg_namespace.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::AtomicU32;
 
 use datafusion::arrow::array::{ArrayRef, Int32Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -15,7 +15,7 @@ use tokio::sync::RwLock;
 
 use crate::pg_catalog::catalog_info::CatalogInfo;
 
-use super::OidCacheKey;
+use super::{OidCacheKey, resolve_oid};
 
 #[derive(Debug, Clone)]
 pub(crate) struct PgNamespaceTable<C> {
@@ -68,11 +68,7 @@ impl<C: CatalogInfo> PgNamespaceTable<C> {
             if let Some(schema_names) = this.catalog_list.schema_names(&catalog_name).await? {
                 for schema_name in schema_names {
                     let cache_key = OidCacheKey::Schema(catalog_name.clone(), schema_name.clone());
-                    let schema_oid = if let Some(oid) = oid_cache.get(&cache_key) {
-                        *oid
-                    } else {
-                        this.oid_counter.fetch_add(1, Ordering::Relaxed)
-                    };
+                    let schema_oid = resolve_oid(&cache_key, &oid_cache, &this.oid_counter);
                     schema_oid_cache.insert(cache_key, schema_oid);
 
                     oids.push(schema_oid as i32);


### PR DESCRIPTION
## What

Pin the `pg_catalog` namespace to its canonical PostgreSQL OID **11** so the static catalog rows this crate ships join back to `pg_namespace`. Closes #390.

## Problem

The static `pg_catalog` data shipped as feather files (`pg_catalog_arrow_exports/*.feather`, produced by `export_pg_catalog_arrow.sh` from a fresh PostgreSQL) stores `typnamespace`/`pronamespace` referencing the canonical `pg_catalog` namespace OID **11**:

```sql
SELECT typnamespace FROM pg_catalog.pg_type WHERE typname = 'text';   -- 11
```

But `pg_namespace`/`pg_class` minted `pg_catalog`'s OID dynamically from the counter (16384+), so **no namespace with OID 11 existed**. Any client joining a system object to its namespace got nothing:

```sql
SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'pg_catalog';   -- 16384, not 11
-- join yields nothing:
SELECT t.typname FROM pg_catalog.pg_type t
JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.typname = 'text';
```

Concrete impact: DBeaver can't resolve **any column's data type** (every column shows as unknown), because the type's `typnamespace` (11) doesn't match the dynamic `pg_catalog` OID.

## Fix

Assign `pg_catalog` its fixed canonical OID via a small helper, used in the two places schema OIDs are minted (`pg_namespace` and `pg_class`):

```rust
const PG_CATALOG_NAMESPACE_OID: Oid = 11;

pub(crate) fn fixed_namespace_oid(schema_name: &str) -> Option<Oid> {
    match schema_name {
        "pg_catalog" => Some(PG_CATALOG_NAMESPACE_OID),
        _ => None,
    }
}

// in pg_namespace.rs / pg_class.rs:
let schema_oid = if let Some(oid) = fixed_namespace_oid(&schema_name) {
    oid
} else if let Some(oid) = oid_cache.get(&cache_key) {
    *oid
} else {
    this.oid_counter.fetch_add(1, Ordering::Relaxed)
};
```

`11` sits below the user range (the counter starts at 16384), so it never collides with a generated OID. Other schemas are unaffected. `pg_class` then reports `relnamespace = 11` for `pg_catalog` objects too, and the fixed value is cached so all four builders agree.

## Test

`pg_catalog_namespace_keeps_fixed_oid_eleven` — asserts `pg_namespace.oid(pg_catalog) == 11` and that a built-in type (`int4`) joins back to its namespace. Fails on `master` (`16384 != 11`), passes with this change.

`cargo fmt --check`, `cargo clippy --all-features -- -D warnings`, the full `datafusion-pg-catalog` suite (49), and the `dbeaver`/`psql`/`pgcli`/`metabase` integration tests all pass.

## Scope (intentional)

This addresses the `pg_catalog` OID from #390 only — the actual DBeaver symptom (built-in types are all `typnamespace = 11`).

The static rows *also* reference `information_schema`'s namespace OID (**13283** — its bootstrap OID in the PG-17 export, not the traditional 13059). That namespace is intentionally left dynamic here: its composite view-types (`_columns`, `_tables`, …) rarely need to be resolved to a namespace, 13283 is a non-canonical export artifact, and pinning a non-canonical magic number felt like the wrong trade-off. Flagged for a possible follow-up (either pin 13283 to match the export, or regenerate the export with canonical OIDs).

Builds on #393.
