### PR TITLE
fix: resolve schema-qualified quoted regclass names

### DIFF
--- a/datafusion-pg-catalog/src/sql/rules.rs
+++ b/datafusion-pg-catalog/src/sql/rules.rs
@@ -909,7 +909,7 @@ const REG_CAST_SPECS: &[RegCastSpec] = &[
     // regclass: relation name -> pg_class.oid
     RegCastSpec {
         type_name: "regclass",
-        query: "SELECT oid FROM pg_catalog.pg_class WHERE relname = $1",
+        query: "SELECT c.oid FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid CROSS JOIN (SELECT parse_ident($1::TEXT) AS parts) WHERE array_length(parts, 1) IN (1, 2) AND ((array_length(parts, 1) = 1 AND n.nspname = current_schema() AND c.relname = parts[1]) OR (array_length(parts, 1) = 2 AND n.nspname = parts[1] AND c.relname = parts[2]))",
     },
     // regnamespace: schema name -> pg_namespace.oid
     RegCastSpec {
@@ -1629,7 +1629,7 @@ mod tests {
         assert_rewrite!(
             &rules,
             "SELECT 'pg_class'::regclass",
-            "SELECT (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'pg_class')"
+            "SELECT (SELECT c.oid FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid CROSS JOIN (SELECT parse_ident('pg_class'::TEXT) AS parts) WHERE array_length(parts, 1) IN (1, 2) AND ((array_length(parts, 1) = 1 AND n.nspname = current_schema() AND c.relname = parts[1]) OR (array_length(parts, 1) = 2 AND n.nspname = parts[1] AND c.relname = parts[2])))"
         );
         assert_rewrite!(
             &rules,
@@ -1646,7 +1646,67 @@ mod tests {
         assert_rewrite!(
             &rules,
             "SELECT 1 WHERE classoid = 'pg_class'::regclass",
-            "SELECT 1 WHERE classoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'pg_class')"
+            "SELECT 1 WHERE classoid = (SELECT c.oid FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid CROSS JOIN (SELECT parse_ident('pg_class'::TEXT) AS parts) WHERE array_length(parts, 1) IN (1, 2) AND ((array_length(parts, 1) = 1 AND n.nspname = current_schema() AND c.relname = parts[1]) OR (array_length(parts, 1) = 2 AND n.nspname = parts[1] AND c.relname = parts[2])))"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_regclass_uses_parse_ident_schema_aware_lookup() {
+        let rules: Vec<Arc<dyn SqlStatementRewriteRule>> =
+            vec![Arc::new(RewriteRegCastToSubquery::new())];
+
+        let lookup = "SELECT c.oid FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid CROSS JOIN (SELECT parse_ident($1::TEXT) AS parts) WHERE array_length(parts, 1) IN (1, 2) AND ((array_length(parts, 1) = 1 AND n.nspname = current_schema() AND c.relname = parts[1]) OR (array_length(parts, 1) = 2 AND n.nspname = parts[1] AND c.relname = parts[2]))";
+
+        // A bound portal parameter remains a parameter through the parse_ident
+        // lookup and outer oid cast.
+        assert_rewrite!(
+            &rules,
+            "SELECT $1::regclass::oid",
+            format!("SELECT ({lookup})::oid")
+        );
+        // The pg_catalog-qualified spelling normalizes to the same template.
+        assert_rewrite!(
+            &rules,
+            "SELECT $1::pg_catalog.regclass",
+            format!("SELECT ({lookup})")
+        );
+        // parse_ident preserves quoted, case-sensitive unqualified names.
+        assert_rewrite!(
+            &rules,
+            "SELECT '\"Mixed Case\"'::regclass",
+            format!("SELECT ({})", lookup.replace("$1", "'\"Mixed Case\"'"))
+        );
+        // Two explicit quoted components select the supplied schema and relation.
+        assert_rewrite!(
+            &rules,
+            "SELECT '\"Mixed Schema\".\"Mixed Table\"'::regclass",
+            format!(
+                "SELECT ({})",
+                lookup.replace("$1", "'\"Mixed Schema\".\"Mixed Table\"'")
+            )
+        );
+        // Invalid and over-qualified names are guarded by the component count.
+        assert_rewrite!(
+            &rules,
+            "SELECT 'too.many.parts'::regclass",
+            format!("SELECT ({})", lookup.replace("$1", "'too.many.parts'"))
+        );
+        assert_rewrite!(
+            &rules,
+            "SELECT 'too..many'::regclass",
+            format!("SELECT ({})", lookup.replace("$1", "'too..many'"))
+        );
+    }
+
+    #[test]
+    fn test_rewrite_regclass_leaves_direct_relname_predicate_unchanged() {
+        let rules: Vec<Arc<dyn SqlStatementRewriteRule>> =
+            vec![Arc::new(RewriteRegCastToSubquery::new())];
+
+        assert_rewrite!(
+            &rules,
+            "SELECT oid FROM pg_catalog.pg_class WHERE relname = $1",
+            "SELECT oid FROM pg_catalog.pg_class WHERE relname = $1"
         );
     }
 


### PR DESCRIPTION
## What

Resolve quoted and schema-qualified relation names when SQL parameters are cast through `regclass`, for example:

```sql
SELECT $1::regclass::oid;
```

This is needed by PostgreSQL clients such as ADBC when they introspect a table through `pg_class`, `pg_attribute`, and `pg_type`.

## Problem

The regclass rewrite currently reduces the cast to a raw relation-name predicate:

```sql
SELECT oid FROM pg_catalog.pg_class WHERE relname = $1
```

That only works when the parameter is an unquoted bare relation name. PostgreSQL clients may bind a correctly escaped identifier such as `"test_adbc_app_logs"`; comparing that text directly with `pg_class.relname` returns no row, so schema introspection reports zero columns. The same rewrite also loses explicit schema qualification.

This is a regression of behavior originally introduced by #288. Its final implementation parsed the identifier and joined `pg_class` to `pg_namespace`; the later generic reg-cast rewrite refactor in #380 replaced the regclass template with the raw `relname = $1` lookup.

## Fix

The regclass lookup now:

- parses the bound text with `parse_ident` so quoted identifiers retain their PostgreSQL meaning;
- resolves an unqualified relation in the current schema;
- resolves a two-part identifier against its explicit schema;
- guards invalid or over-qualified component counts;
- leaves the parameter in the rewritten subquery, so extended-query prepare/bind remains supported;
- does not rewrite an ordinary `pg_class.relname = $1` predicate.

The lookup joins `pg_class` to `pg_namespace`, which also benefits from the stable namespace OID fixes included in `datafusion-pg-catalog 0.18.2`.

## Tests

Unit coverage includes:

- `$1::regclass::oid`;
- the `pg_catalog.regclass` spelling;
- quoted mixed-case names;
- quoted schema-qualified names;
- invalid/over-qualified names;
- a control proving a direct `relname = $1` predicate is unchanged.

Downstream GreptimeDB PostgreSQL-protocol coverage prepares the pgADBC-shaped catalog query and binds bare, quoted, and schema-qualified table names. It also checks current-schema selection and proves that quoted text does not match a raw `relname` predicate.

Validated on the upstream-master-based head `2deb97589ff060c7ec9dbeabe135a45590313203`:

- `cargo +stable fmt -- --check`
- `cargo +stable test -p datafusion-pg-catalog --all-features` — 51 passed
- `cargo +stable clippy -p datafusion-pg-catalog --all-features -- -D warnings`
- upstream-relative `git diff --check`

The upstream CI matrix will additionally run stable/nightly workspace tests, workspace all-feature Clippy, MSRV, Nix clean-build, and integration jobs.

## Scope

This only fixes name lookup for `regclass` casts. It does not change the other `reg*` casts, reverse symbolic display, or PostgreSQL wire encoding.

Related: #288, #380.
